### PR TITLE
fix(stubs): /account links → /account/profile

### DIFF
--- a/packages/create-mantiq/stubs/react/src/components/layout/nav-user.tsx.stub
+++ b/packages/create-mantiq/stubs/react/src/components/layout/nav-user.tsx.stub
@@ -87,7 +87,7 @@ export function NavUser({ user, navigate, onLogout }: NavUserProps) {
               </div>
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={() => navigate('/account')}>
+            <DropdownMenuItem onClick={() => navigate('/account/profile')}>
               <User className="mr-2 h-4 w-4" />
               Account
             </DropdownMenuItem>

--- a/packages/create-mantiq/stubs/react/src/components/layout/sidebar-data.ts.stub
+++ b/packages/create-mantiq/stubs/react/src/components/layout/sidebar-data.ts.stub
@@ -44,7 +44,7 @@ export const sidebarData: NavGroup[] = [
     items: [
       {
         title: 'Settings',
-        url: '/account',
+        url: '/account/profile',
         icon: Settings,
         items: [
           { title: 'Profile', url: '/account/profile', icon: User },

--- a/packages/create-mantiq/stubs/svelte/src/lib/components/layout/sidebar-data.ts.stub
+++ b/packages/create-mantiq/stubs/svelte/src/lib/components/layout/sidebar-data.ts.stub
@@ -44,7 +44,7 @@ export const sidebarData: NavGroup[] = [
     items: [
       {
         title: 'Settings',
-        url: '/account',
+        url: '/account/profile',
         icon: Settings,
         items: [
           { title: 'Profile', url: '/account/profile', icon: User },

--- a/packages/create-mantiq/stubs/vue/src/components/layout/sidebar-data.ts.stub
+++ b/packages/create-mantiq/stubs/vue/src/components/layout/sidebar-data.ts.stub
@@ -44,7 +44,7 @@ export const sidebarData: NavGroup[] = [
     items: [
       {
         title: 'Settings',
-        url: '/account',
+        url: '/account/profile',
         icon: Settings,
         items: [
           { title: 'Profile', url: '/account/profile', icon: User },


### PR DESCRIPTION
## Summary

The Settings parent item in sidebar-data and React's nav-user dropdown linked to `/account` which has no route (only `/account/profile`, `/account/security`, `/account/preferences` exist). Fixed to `/account/profile` across all 3 kits.

## Changes

- `stubs/react/src/components/layout/sidebar-data.ts.stub` — Settings url
- `stubs/react/src/components/layout/nav-user.tsx.stub` — Account dropdown item
- `stubs/vue/src/components/layout/sidebar-data.ts.stub` — Settings url
- `stubs/svelte/src/lib/components/layout/sidebar-data.ts.stub` — Settings url

## Test plan

- [ ] CI passes
- [ ] Scaffold React app → click Settings in sidebar → navigates to /account/profile (not 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)