### PR TITLE
feat: @mantiq/oauth (server) + @mantiq/social-auth (client)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,8 +27,8 @@
       "name": "@mantiq/docs",
       "version": "0.0.1",
       "dependencies": {
-        "@mantiq/core": "workspace:*",
-        "@mantiq/vite": "workspace:*",
+        "@mantiq/core": "^0.1.4",
+        "@mantiq/vite": "^0.1.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.0",
         "lucide-react": "^0.460.0",
@@ -50,7 +50,7 @@
     },
     "packages/auth": {
       "name": "@mantiq/auth",
-      "version": "0.1.3",
+      "version": "0.2.1",
       "devDependencies": {
         "@mantiq/core": "workspace:*",
         "@mantiq/database": "workspace:*",
@@ -81,7 +81,7 @@
     },
     "packages/core": {
       "name": "@mantiq/core",
-      "version": "0.1.4",
+      "version": "0.2.1",
       "devDependencies": {
         "bun-types": "latest",
         "typescript": "^5.7.0",
@@ -98,7 +98,7 @@
     },
     "packages/create-mantiq": {
       "name": "create-mantiq",
-      "version": "0.5.1",
+      "version": "0.7.0",
       "bin": {
         "create-mantiq": "./src/index.ts",
       },
@@ -269,6 +269,22 @@
         "@mantiq/realtime": "^0.1.0",
       },
     },
+    "packages/oauth": {
+      "name": "@mantiq/oauth",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@mantiq/auth": "workspace:*",
+        "@mantiq/core": "workspace:*",
+        "@mantiq/database": "workspace:*",
+        "bun-types": "latest",
+        "typescript": "^5.7.0",
+      },
+      "peerDependencies": {
+        "@mantiq/auth": "^0.2.0",
+        "@mantiq/core": "^0.2.0",
+        "@mantiq/database": "^0.2.0",
+      },
+    },
     "packages/queue": {
       "name": "@mantiq/queue",
       "version": "0.1.3",
@@ -319,9 +335,21 @@
         "@mantiq/database": "^0.1.0",
       },
     },
+    "packages/social-auth": {
+      "name": "@mantiq/social-auth",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@mantiq/core": "workspace:*",
+        "bun-types": "latest",
+        "typescript": "^5.7.0",
+      },
+      "peerDependencies": {
+        "@mantiq/core": "^0.2.0",
+      },
+    },
     "packages/validation": {
       "name": "@mantiq/validation",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "devDependencies": {
         "@mantiq/core": "workspace:*",
         "bun-types": "latest",
@@ -517,11 +545,15 @@
 
     "@mantiq/notify": ["@mantiq/notify@workspace:packages/notify"],
 
+    "@mantiq/oauth": ["@mantiq/oauth@workspace:packages/oauth"],
+
     "@mantiq/queue": ["@mantiq/queue@workspace:packages/queue"],
 
     "@mantiq/realtime": ["@mantiq/realtime@workspace:packages/realtime"],
 
     "@mantiq/search": ["@mantiq/search@workspace:packages/search"],
+
+    "@mantiq/social-auth": ["@mantiq/social-auth@workspace:packages/social-auth"],
 
     "@mantiq/validation": ["@mantiq/validation@workspace:packages/validation"],
 
@@ -1064,6 +1096,8 @@
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "@mantiq/docs/@mantiq/core": ["@mantiq/core@0.1.4", "", { "peerDependencies": { "bun": ">=1.1.0", "ioredis": ">=5.0.0", "memjs": ">=1.3.0" }, "optionalPeers": ["ioredis", "memjs"] }, "sha512-E1tbXsdYkqtmd0EbBbBkbT3hAZ3FyCmHdR+kKjimdtf7ZTfGFsbVXHE4R1Cf8xpk66e9d2Cw4Vs2VNkhFRkqRg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w=="],
 

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@mantiq/oauth",
+  "version": "0.1.0",
+  "description": "OAuth 2.0 server — authorization code (PKCE), client credentials, JWT access tokens, scopes",
+  "type": "module",
+  "license": "MIT",
+  "author": "Abdullah Khan",
+  "homepage": "https://github.com/mantiqjs/mantiq/tree/main/packages/oauth",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mantiqjs/mantiq.git",
+    "directory": "packages/oauth"
+  },
+  "bugs": {
+    "url": "https://github.com/mantiqjs/mantiq/issues"
+  },
+  "keywords": ["mantiq", "oauth", "oauth2", "jwt", "authorization", "token"],
+  "engines": { "bun": ">=1.1.0" },
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": { ".": { "bun": "./src/index.ts", "default": "./src/index.ts" } },
+  "files": ["src/", "package.json", "README.md"],
+  "scripts": {
+    "build": "bun build ./src/index.ts --outdir ./dist --target bun --packages=external",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "peerDependencies": {
+    "@mantiq/core": "^0.2.0",
+    "@mantiq/database": "^0.2.0",
+    "@mantiq/auth": "^0.2.0"
+  },
+  "devDependencies": {
+    "bun-types": "latest",
+    "typescript": "^5.7.0",
+    "@mantiq/core": "workspace:*",
+    "@mantiq/database": "workspace:*",
+    "@mantiq/auth": "workspace:*"
+  }
+}

--- a/packages/oauth/src/OAuthServer.ts
+++ b/packages/oauth/src/OAuthServer.ts
@@ -1,0 +1,75 @@
+export interface OAuthConfig {
+  /**
+   * Lifetime of access tokens in seconds.
+   * @default 3600 (1 hour)
+   */
+  tokenLifetime?: number
+
+  /**
+   * Lifetime of refresh tokens in seconds.
+   * @default 1209600 (14 days)
+   */
+  refreshTokenLifetime?: number
+
+  /**
+   * Path to the RSA private key PEM file.
+   */
+  privateKeyPath?: string
+
+  /**
+   * Path to the RSA public key PEM file.
+   */
+  publicKeyPath?: string
+}
+
+/**
+ * Central OAuth server configuration holder.
+ * Manages scopes and token lifetimes.
+ */
+export class OAuthServer {
+  private _scopes = new Map<string, string>()
+
+  constructor(private config: OAuthConfig) {}
+
+  get tokenLifetime(): number {
+    return this.config.tokenLifetime ?? 3600
+  }
+
+  get refreshTokenLifetime(): number {
+    return this.config.refreshTokenLifetime ?? 1209600
+  }
+
+  get privateKeyPath(): string {
+    return this.config.privateKeyPath ?? 'storage/oauth-private.key'
+  }
+
+  get publicKeyPath(): string {
+    return this.config.publicKeyPath ?? 'storage/oauth-public.key'
+  }
+
+  /**
+   * Register scopes that tokens can be issued with.
+   */
+  tokensCan(scopes: Record<string, string>): void {
+    for (const [id, description] of Object.entries(scopes)) {
+      this._scopes.set(id, description)
+    }
+  }
+
+  /**
+   * Check if a scope is registered.
+   */
+  hasScope(scope: string): boolean {
+    return this._scopes.has(scope)
+  }
+
+  /**
+   * Get all registered scopes.
+   */
+  scopes(): Array<{ id: string; description: string }> {
+    return Array.from(this._scopes.entries()).map(([id, description]) => ({
+      id,
+      description,
+    }))
+  }
+}

--- a/packages/oauth/src/OAuthServiceProvider.ts
+++ b/packages/oauth/src/OAuthServiceProvider.ts
@@ -1,0 +1,89 @@
+import { ServiceProvider, ConfigRepository } from '@mantiq/core'
+import type { Router } from '@mantiq/core'
+import { ROUTER } from '@mantiq/core'
+import { AuthManager } from '@mantiq/auth'
+import { OAuthServer } from './OAuthServer.ts'
+import type { OAuthConfig } from './OAuthServer.ts'
+import { JwtSigner } from './jwt/JwtSigner.ts'
+import { JwtGuard } from './guards/JwtGuard.ts'
+import { CheckScopes } from './middleware/CheckScopes.ts'
+import { CheckForAnyScope } from './middleware/CheckForAnyScope.ts'
+import { CheckClientCredentials } from './middleware/CheckClientCredentials.ts'
+import { AuthCodeGrant } from './grants/AuthCodeGrant.ts'
+import { ClientCredentialsGrant } from './grants/ClientCredentialsGrant.ts'
+import { RefreshTokenGrant } from './grants/RefreshTokenGrant.ts'
+import { PersonalAccessGrant } from './grants/PersonalAccessGrant.ts'
+import { oauthRoutes } from './routes/oauthRoutes.ts'
+import { OAUTH_SERVER } from './helpers/oauth.ts'
+import { readFile } from 'node:fs/promises'
+
+const DEFAULT_CONFIG: OAuthConfig = {
+  tokenLifetime: 3600,
+  refreshTokenLifetime: 1209600,
+  privateKeyPath: 'storage/oauth-private.key',
+  publicKeyPath: 'storage/oauth-public.key',
+}
+
+/**
+ * Service provider for the OAuth package.
+ *
+ * register(): binds OAuthServer + JwtSigner as singletons
+ * boot(): loads keys, registers the 'oauth' guard on AuthManager, registers routes, binds middleware
+ */
+export class OAuthServiceProvider extends ServiceProvider {
+  override register(): void {
+    // OAuthServer singleton
+    this.app.singleton(OAuthServer, (c) => {
+      const config = c.make(ConfigRepository).get<OAuthConfig>('oauth', DEFAULT_CONFIG)
+      return new OAuthServer(config)
+    })
+    this.app.alias(OAuthServer, OAUTH_SERVER)
+
+    // JwtSigner singleton
+    this.app.singleton(JwtSigner, () => new JwtSigner())
+
+    // Middleware bindings
+    this.app.bind(CheckScopes, () => new CheckScopes())
+    this.app.bind(CheckForAnyScope, () => new CheckForAnyScope())
+    this.app.bind(CheckClientCredentials, (c) => new CheckClientCredentials(c.make(JwtSigner)))
+  }
+
+  override async boot(): Promise<void> {
+    const server = this.app.make(OAuthServer)
+    const signer = this.app.make(JwtSigner)
+
+    // Load RSA keys if they exist
+    try {
+      const privateKey = await readFile(server.privateKeyPath, 'utf-8')
+      const publicKey = await readFile(server.publicKeyPath, 'utf-8')
+      await signer.loadKeys(privateKey, publicKey)
+    } catch {
+      // Keys not yet generated — oauth:install must be run first
+    }
+
+    // Register 'oauth' guard on AuthManager
+    try {
+      const authManager = this.app.make(AuthManager)
+      authManager.extend('oauth', () => {
+        const provider = authManager.createUserProvider('users')
+        return new JwtGuard(signer, provider)
+      })
+    } catch {
+      // AuthManager not available — @mantiq/auth may not be installed
+    }
+
+    // Register OAuth routes
+    try {
+      const router = this.app.make<Router>(ROUTER)
+      const grants = [
+        new AuthCodeGrant(signer, server),
+        new ClientCredentialsGrant(signer, server),
+        new RefreshTokenGrant(signer, server),
+        new PersonalAccessGrant(signer, server),
+      ]
+      oauthRoutes(router, { server, grants })
+    } catch {
+      // Router not available
+    }
+  }
+}

--- a/packages/oauth/src/commands/OAuthClientCommand.ts
+++ b/packages/oauth/src/commands/OAuthClientCommand.ts
@@ -1,0 +1,50 @@
+import { Command } from '@mantiq/cli'
+import type { ParsedArgs } from '@mantiq/cli'
+import { Client } from '../models/Client.ts'
+
+/**
+ * Create a new OAuth client.
+ *
+ * Usage: mantiq oauth:client <name> [--redirect=URL] [--personal] [--password]
+ */
+export class OAuthClientCommand extends Command {
+  override name = 'oauth:client'
+  override description = 'Create a new OAuth client'
+  override usage = 'oauth:client <name> [--redirect=URL] [--personal] [--password]'
+
+  override async handle(args: ParsedArgs): Promise<number> {
+    const name = args.args[0]
+    if (!name) {
+      this.io.error('Client name is required.')
+      this.io.muted('  Usage: mantiq oauth:client <name> [--redirect=URL]')
+      return 1
+    }
+
+    const redirect = (args.flags['redirect'] as string) || 'http://localhost'
+    const personal = !!args.flags['personal']
+    const password = !!args.flags['password']
+
+    const clientId = crypto.randomUUID()
+    const secret = crypto.randomUUID()
+
+    await Client.create({
+      id: clientId,
+      name,
+      secret,
+      redirect,
+      personal_access_client: personal,
+      password_client: password,
+      revoked: false,
+    })
+
+    this.io.success(`OAuth client "${name}" created successfully.`)
+    this.io.newLine()
+    this.io.twoColumn('Client ID:', clientId)
+    this.io.twoColumn('Client Secret:', secret)
+    this.io.twoColumn('Redirect URL:', redirect)
+    this.io.twoColumn('Personal Access:', personal ? 'Yes' : 'No')
+    this.io.twoColumn('Password Grant:', password ? 'Yes' : 'No')
+
+    return 0
+  }
+}

--- a/packages/oauth/src/commands/OAuthInstallCommand.ts
+++ b/packages/oauth/src/commands/OAuthInstallCommand.ts
@@ -1,0 +1,67 @@
+import { Command } from '@mantiq/cli'
+import type { ParsedArgs } from '@mantiq/cli'
+import { JwtSigner } from '../jwt/JwtSigner.ts'
+import { Client } from '../models/Client.ts'
+import { writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+
+/**
+ * Generate OAuth RSA keys and create a personal access client.
+ *
+ * Usage: mantiq oauth:install
+ */
+export class OAuthInstallCommand extends Command {
+  override name = 'oauth:install'
+  override description = 'Run the commands necessary to prepare OAuth for use'
+
+  override async handle(_args: ParsedArgs): Promise<number> {
+    this.io.info('Installing OAuth server...')
+
+    // Generate keys
+    const signer = new JwtSigner()
+    const keyPair = await signer.generateKeyPair()
+
+    const privatePath = 'storage/oauth-private.key'
+    const publicPath = 'storage/oauth-public.key'
+
+    const privateExists = existsSync(privatePath)
+    const publicExists = existsSync(publicPath)
+
+    if (privateExists || publicExists) {
+      this.io.warn('OAuth keys already exist. Skipping key generation.')
+    } else {
+      await writeFile(privatePath, keyPair.privateKey, 'utf-8')
+      await writeFile(publicPath, keyPair.publicKey, 'utf-8')
+      this.io.success('OAuth keys generated successfully.')
+      this.io.muted(`  Private key: ${privatePath}`)
+      this.io.muted(`  Public key:  ${publicPath}`)
+    }
+
+    // Create personal access client
+    const existingClient = await Client.where('personal_access_client', true).first()
+    if (existingClient) {
+      this.io.warn('Personal access client already exists. Skipping.')
+    } else {
+      const clientId = crypto.randomUUID()
+      const secret = crypto.randomUUID()
+
+      await Client.create({
+        id: clientId,
+        name: 'Personal Access Client',
+        secret,
+        redirect: 'http://localhost',
+        personal_access_client: true,
+        password_client: false,
+        revoked: false,
+      })
+
+      this.io.success('Personal access client created successfully.')
+      this.io.muted(`  Client ID:     ${clientId}`)
+      this.io.muted(`  Client Secret: ${secret}`)
+    }
+
+    this.io.newLine()
+    this.io.success('OAuth installation complete.')
+    return 0
+  }
+}

--- a/packages/oauth/src/commands/OAuthKeysCommand.ts
+++ b/packages/oauth/src/commands/OAuthKeysCommand.ts
@@ -1,0 +1,43 @@
+import { Command } from '@mantiq/cli'
+import type { ParsedArgs } from '@mantiq/cli'
+import { JwtSigner } from '../jwt/JwtSigner.ts'
+import { writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+
+/**
+ * Generate the RSA key pair for signing JWTs.
+ *
+ * Usage: mantiq oauth:keys [--force]
+ */
+export class OAuthKeysCommand extends Command {
+  override name = 'oauth:keys'
+  override description = 'Generate the encryption keys for API authentication'
+  override usage = 'oauth:keys [--force]'
+
+  override async handle(args: ParsedArgs): Promise<number> {
+    const force = !!args.flags['force']
+    const privatePath = 'storage/oauth-private.key'
+    const publicPath = 'storage/oauth-public.key'
+
+    if (!force) {
+      if (existsSync(privatePath) || existsSync(publicPath)) {
+        this.io.error('OAuth keys already exist. Use --force to overwrite.')
+        return 1
+      }
+    }
+
+    this.io.info('Generating RSA key pair...')
+
+    const signer = new JwtSigner()
+    const keyPair = await signer.generateKeyPair()
+
+    await writeFile(privatePath, keyPair.privateKey, 'utf-8')
+    await writeFile(publicPath, keyPair.publicKey, 'utf-8')
+
+    this.io.success('OAuth keys generated successfully.')
+    this.io.muted(`  Private key: ${privatePath}`)
+    this.io.muted(`  Public key:  ${publicPath}`)
+
+    return 0
+  }
+}

--- a/packages/oauth/src/commands/OAuthPurgeCommand.ts
+++ b/packages/oauth/src/commands/OAuthPurgeCommand.ts
@@ -1,0 +1,89 @@
+import { Command } from '@mantiq/cli'
+import type { ParsedArgs } from '@mantiq/cli'
+import { AccessToken } from '../models/AccessToken.ts'
+import { RefreshToken } from '../models/RefreshToken.ts'
+import { AuthCode } from '../models/AuthCode.ts'
+
+/**
+ * Purge expired and revoked OAuth tokens.
+ *
+ * Usage: mantiq oauth:purge [--revoked]
+ */
+export class OAuthPurgeCommand extends Command {
+  override name = 'oauth:purge'
+  override description = 'Purge revoked and/or expired tokens and auth codes'
+  override usage = 'oauth:purge [--revoked]'
+
+  override async handle(args: ParsedArgs): Promise<number> {
+    const revokedOnly = !!args.flags['revoked']
+
+    this.io.info('Purging OAuth tokens...')
+
+    const now = new Date().toISOString()
+    let purgedTokens = 0
+    let purgedRefresh = 0
+    let purgedCodes = 0
+
+    if (revokedOnly) {
+      // Only purge revoked tokens
+      const revokedAccessTokens = await AccessToken.where('revoked', true).get()
+      for (const token of revokedAccessTokens) {
+        await token.delete()
+        purgedTokens++
+      }
+
+      const revokedRefreshTokens = await RefreshToken.where('revoked', true).get()
+      for (const token of revokedRefreshTokens) {
+        await token.delete()
+        purgedRefresh++
+      }
+
+      const revokedAuthCodes = await AuthCode.where('revoked', true).get()
+      for (const code of revokedAuthCodes) {
+        await code.delete()
+        purgedCodes++
+      }
+    } else {
+      // Purge expired + revoked
+      const expiredAccessTokens = await AccessToken.where('expires_at', '<', now).get()
+      const revokedAccessTokens = await AccessToken.where('revoked', true).get()
+      const allAccessTokens = new Map<string, typeof expiredAccessTokens[0]>()
+      for (const t of [...expiredAccessTokens, ...revokedAccessTokens]) {
+        allAccessTokens.set(t.getKey() as string, t)
+      }
+      for (const token of allAccessTokens.values()) {
+        await token.delete()
+        purgedTokens++
+      }
+
+      const expiredRefreshTokens = await RefreshToken.where('expires_at', '<', now).get()
+      const revokedRefreshTokens = await RefreshToken.where('revoked', true).get()
+      const allRefreshTokens = new Map<string, typeof expiredRefreshTokens[0]>()
+      for (const t of [...expiredRefreshTokens, ...revokedRefreshTokens]) {
+        allRefreshTokens.set(t.getKey() as string, t)
+      }
+      for (const token of allRefreshTokens.values()) {
+        await token.delete()
+        purgedRefresh++
+      }
+
+      const expiredAuthCodes = await AuthCode.where('expires_at', '<', now).get()
+      const revokedAuthCodes = await AuthCode.where('revoked', true).get()
+      const allAuthCodes = new Map<string, typeof expiredAuthCodes[0]>()
+      for (const c of [...expiredAuthCodes, ...revokedAuthCodes]) {
+        allAuthCodes.set(c.getKey() as string, c)
+      }
+      for (const code of allAuthCodes.values()) {
+        await code.delete()
+        purgedCodes++
+      }
+    }
+
+    this.io.success('Purge complete.')
+    this.io.twoColumn('Access tokens purged:', String(purgedTokens))
+    this.io.twoColumn('Refresh tokens purged:', String(purgedRefresh))
+    this.io.twoColumn('Auth codes purged:', String(purgedCodes))
+
+    return 0
+  }
+}

--- a/packages/oauth/src/errors/OAuthError.ts
+++ b/packages/oauth/src/errors/OAuthError.ts
@@ -1,0 +1,22 @@
+import { HttpError } from '@mantiq/core'
+
+/**
+ * OAuth-specific error.
+ * Defaults to 400 Bad Request. Use a different status code for specific cases.
+ */
+export class OAuthError extends HttpError {
+  constructor(
+    message: string,
+    public readonly errorCode: string = 'invalid_request',
+    statusCode = 400,
+  ) {
+    super(statusCode, message)
+  }
+
+  toJSON(): Record<string, any> {
+    return {
+      error: this.errorCode,
+      error_description: this.message,
+    }
+  }
+}

--- a/packages/oauth/src/grants/AuthCodeGrant.ts
+++ b/packages/oauth/src/grants/AuthCodeGrant.ts
@@ -1,0 +1,159 @@
+import type { MantiqRequest } from '@mantiq/core'
+import type { GrantHandler, OAuthTokenResponse } from './GrantHandler.ts'
+import type { JwtSigner } from '../jwt/JwtSigner.ts'
+import type { OAuthServer } from '../OAuthServer.ts'
+import { Client } from '../models/Client.ts'
+import { AuthCode } from '../models/AuthCode.ts'
+import { AccessToken } from '../models/AccessToken.ts'
+import { RefreshToken } from '../models/RefreshToken.ts'
+import { OAuthError } from '../errors/OAuthError.ts'
+
+/**
+ * Authorization Code grant with PKCE support.
+ */
+export class AuthCodeGrant implements GrantHandler {
+  readonly grantType = 'authorization_code'
+
+  constructor(
+    private readonly signer: JwtSigner,
+    private readonly server: OAuthServer,
+  ) {}
+
+  async handle(request: MantiqRequest): Promise<OAuthTokenResponse> {
+    const code = await request.input('code') as string | undefined
+    const redirectUri = await request.input('redirect_uri') as string | undefined
+    const clientId = await request.input('client_id') as string | undefined
+    const clientSecret = await request.input('client_secret') as string | undefined
+    const codeVerifier = await request.input('code_verifier') as string | undefined
+
+    if (!code) throw new OAuthError('The code parameter is required.', 'invalid_request')
+    if (!clientId) throw new OAuthError('The client_id parameter is required.', 'invalid_request')
+    if (!redirectUri) throw new OAuthError('The redirect_uri parameter is required.', 'invalid_request')
+
+    // Resolve client
+    const client = await Client.find(clientId)
+    if (!client) throw new OAuthError('Client not found.', 'invalid_client', 401)
+
+    // Verify client secret for confidential clients
+    if (client.confidential()) {
+      if (!clientSecret || clientSecret !== client.getAttribute('secret')) {
+        throw new OAuthError('Invalid client credentials.', 'invalid_client', 401)
+      }
+    }
+
+    // Resolve auth code
+    const authCode = await AuthCode.where('id', code)
+      .where('revoked', false)
+      .first() as AuthCode | null
+
+    if (!authCode) throw new OAuthError('Invalid authorization code.', 'invalid_grant')
+
+    // Verify the code belongs to this client
+    if (authCode.getAttribute('client_id') !== clientId) {
+      throw new OAuthError('Authorization code does not belong to this client.', 'invalid_grant')
+    }
+
+    // Check expiration
+    const expiresAt = authCode.getAttribute('expires_at')
+    if (expiresAt && new Date(expiresAt) < new Date()) {
+      throw new OAuthError('Authorization code has expired.', 'invalid_grant')
+    }
+
+    // Verify PKCE code_challenge
+    const storedChallenge = authCode.getAttribute('code_challenge') as string | null
+    const challengeMethod = (authCode.getAttribute('code_challenge_method') as string) || 'plain'
+
+    if (storedChallenge) {
+      if (!codeVerifier) {
+        throw new OAuthError('The code_verifier parameter is required.', 'invalid_request')
+      }
+      const isValid = await this.verifyCodeChallenge(codeVerifier, storedChallenge, challengeMethod)
+      if (!isValid) {
+        throw new OAuthError('Invalid code verifier.', 'invalid_grant')
+      }
+    }
+
+    // Revoke the auth code (single use)
+    authCode.setAttribute('revoked', true)
+    await authCode.save()
+
+    // Issue tokens
+    const userId = authCode.getAttribute('user_id') as string
+    const scopes = (authCode.getAttribute('scopes') as string[]) || []
+    const tokenId = crypto.randomUUID()
+    const now = Math.floor(Date.now() / 1000)
+
+    // Create access token record
+    await AccessToken.create({
+      id: tokenId,
+      user_id: userId,
+      client_id: clientId,
+      name: null,
+      scopes: JSON.stringify(scopes),
+      revoked: false,
+      expires_at: new Date((now + this.server.tokenLifetime) * 1000).toISOString(),
+    })
+
+    // Create refresh token
+    const refreshTokenId = crypto.randomUUID()
+    await RefreshToken.create({
+      id: refreshTokenId,
+      access_token_id: tokenId,
+      revoked: false,
+      expires_at: new Date((now + this.server.refreshTokenLifetime) * 1000).toISOString(),
+    })
+
+    // Sign JWT
+    const jwt = await this.signer.sign({
+      iss: 'mantiq-oauth',
+      sub: userId,
+      aud: clientId,
+      exp: now + this.server.tokenLifetime,
+      iat: now,
+      jti: tokenId,
+      scopes,
+    })
+
+    return {
+      token_type: 'Bearer',
+      expires_in: this.server.tokenLifetime,
+      access_token: jwt,
+      refresh_token: refreshTokenId,
+      scope: scopes.join(' '),
+    }
+  }
+
+  /**
+   * Verify the PKCE code challenge.
+   */
+  private async verifyCodeChallenge(
+    codeVerifier: string,
+    codeChallenge: string,
+    method: string,
+  ): Promise<boolean> {
+    if (method === 'plain') {
+      return codeVerifier === codeChallenge
+    }
+
+    if (method === 'S256') {
+      const encoder = new TextEncoder()
+      const data = encoder.encode(codeVerifier)
+      const hashBuffer = await crypto.subtle.digest('SHA-256', data)
+      const hashArray = new Uint8Array(hashBuffer)
+
+      // Base64URL encode the hash
+      let binary = ''
+      for (let i = 0; i < hashArray.length; i++) {
+        binary += String.fromCharCode(hashArray[i]!)
+      }
+      const base64url = btoa(binary)
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '')
+
+      return base64url === codeChallenge
+    }
+
+    throw new OAuthError(`Unsupported code challenge method: ${method}`, 'invalid_request')
+  }
+}

--- a/packages/oauth/src/grants/ClientCredentialsGrant.ts
+++ b/packages/oauth/src/grants/ClientCredentialsGrant.ts
@@ -1,0 +1,79 @@
+import type { MantiqRequest } from '@mantiq/core'
+import type { GrantHandler, OAuthTokenResponse } from './GrantHandler.ts'
+import type { JwtSigner } from '../jwt/JwtSigner.ts'
+import type { OAuthServer } from '../OAuthServer.ts'
+import { Client } from '../models/Client.ts'
+import { AccessToken } from '../models/AccessToken.ts'
+import { OAuthError } from '../errors/OAuthError.ts'
+
+/**
+ * Client Credentials grant — machine-to-machine authentication.
+ * No user involved, no refresh token issued.
+ */
+export class ClientCredentialsGrant implements GrantHandler {
+  readonly grantType = 'client_credentials'
+
+  constructor(
+    private readonly signer: JwtSigner,
+    private readonly server: OAuthServer,
+  ) {}
+
+  async handle(request: MantiqRequest): Promise<OAuthTokenResponse> {
+    const clientId = await request.input('client_id') as string | undefined
+    const clientSecret = await request.input('client_secret') as string | undefined
+    const scopeParam = await request.input('scope') as string | undefined
+
+    if (!clientId) throw new OAuthError('The client_id parameter is required.', 'invalid_request')
+    if (!clientSecret) throw new OAuthError('The client_secret parameter is required.', 'invalid_request')
+
+    // Resolve client
+    const client = await Client.find(clientId)
+    if (!client) throw new OAuthError('Client not found.', 'invalid_client', 401)
+
+    // Verify secret
+    if (clientSecret !== client.getAttribute('secret')) {
+      throw new OAuthError('Invalid client credentials.', 'invalid_client', 401)
+    }
+
+    // Parse requested scopes
+    const scopes = scopeParam ? scopeParam.split(' ').filter(Boolean) : []
+
+    // Validate scopes
+    for (const scope of scopes) {
+      if (!this.server.hasScope(scope)) {
+        throw new OAuthError(`Invalid scope: ${scope}`, 'invalid_scope')
+      }
+    }
+
+    const tokenId = crypto.randomUUID()
+    const now = Math.floor(Date.now() / 1000)
+
+    // Create access token record (no user_id for client credentials)
+    await AccessToken.create({
+      id: tokenId,
+      user_id: null,
+      client_id: clientId,
+      name: null,
+      scopes: JSON.stringify(scopes),
+      revoked: false,
+      expires_at: new Date((now + this.server.tokenLifetime) * 1000).toISOString(),
+    })
+
+    // Sign JWT (no sub — no user)
+    const jwt = await this.signer.sign({
+      iss: 'mantiq-oauth',
+      aud: clientId,
+      exp: now + this.server.tokenLifetime,
+      iat: now,
+      jti: tokenId,
+      scopes,
+    })
+
+    return {
+      token_type: 'Bearer',
+      expires_in: this.server.tokenLifetime,
+      access_token: jwt,
+      scope: scopes.join(' ') || undefined,
+    }
+  }
+}

--- a/packages/oauth/src/grants/GrantHandler.ts
+++ b/packages/oauth/src/grants/GrantHandler.ts
@@ -1,0 +1,14 @@
+import type { MantiqRequest } from '@mantiq/core'
+
+export interface OAuthTokenResponse {
+  token_type: 'Bearer'
+  expires_in: number
+  access_token: string
+  refresh_token?: string
+  scope?: string
+}
+
+export interface GrantHandler {
+  readonly grantType: string
+  handle(request: MantiqRequest): Promise<OAuthTokenResponse>
+}

--- a/packages/oauth/src/grants/PersonalAccessGrant.ts
+++ b/packages/oauth/src/grants/PersonalAccessGrant.ts
@@ -1,0 +1,72 @@
+import type { MantiqRequest } from '@mantiq/core'
+import type { GrantHandler, OAuthTokenResponse } from './GrantHandler.ts'
+import type { JwtSigner } from '../jwt/JwtSigner.ts'
+import type { OAuthServer } from '../OAuthServer.ts'
+import { AccessToken } from '../models/AccessToken.ts'
+import { OAuthError } from '../errors/OAuthError.ts'
+
+/**
+ * Personal Access Token grant — for authenticated users creating
+ * their own API tokens with specific scopes.
+ */
+export class PersonalAccessGrant implements GrantHandler {
+  readonly grantType = 'personal_access'
+
+  constructor(
+    private readonly signer: JwtSigner,
+    private readonly server: OAuthServer,
+  ) {}
+
+  async handle(request: MantiqRequest): Promise<OAuthTokenResponse> {
+    const user = request.user<any>()
+    if (!user) throw new OAuthError('User must be authenticated.', 'invalid_request', 401)
+
+    const scopeParam = await request.input('scope') as string | undefined
+    const name = await request.input('name') as string | undefined
+
+    // Parse requested scopes
+    const scopes = scopeParam ? scopeParam.split(' ').filter(Boolean) : []
+
+    // Validate scopes
+    for (const scope of scopes) {
+      if (!this.server.hasScope(scope)) {
+        throw new OAuthError(`Invalid scope: ${scope}`, 'invalid_scope')
+      }
+    }
+
+    const userId = typeof user.getAuthIdentifier === 'function'
+      ? user.getAuthIdentifier()
+      : user.id ?? user.getAttribute?.('id')
+
+    const tokenId = crypto.randomUUID()
+    const now = Math.floor(Date.now() / 1000)
+
+    // Create access token record
+    await AccessToken.create({
+      id: tokenId,
+      user_id: String(userId),
+      client_id: null,
+      name: name ?? 'Personal Access Token',
+      scopes: JSON.stringify(scopes),
+      revoked: false,
+      expires_at: new Date((now + this.server.tokenLifetime) * 1000).toISOString(),
+    })
+
+    // Sign JWT
+    const jwt = await this.signer.sign({
+      iss: 'mantiq-oauth',
+      sub: String(userId),
+      exp: now + this.server.tokenLifetime,
+      iat: now,
+      jti: tokenId,
+      scopes,
+    })
+
+    return {
+      token_type: 'Bearer',
+      expires_in: this.server.tokenLifetime,
+      access_token: jwt,
+      scope: scopes.join(' ') || undefined,
+    }
+  }
+}

--- a/packages/oauth/src/grants/RefreshTokenGrant.ts
+++ b/packages/oauth/src/grants/RefreshTokenGrant.ts
@@ -1,0 +1,129 @@
+import type { MantiqRequest } from '@mantiq/core'
+import type { GrantHandler, OAuthTokenResponse } from './GrantHandler.ts'
+import type { JwtSigner } from '../jwt/JwtSigner.ts'
+import type { OAuthServer } from '../OAuthServer.ts'
+import { Client } from '../models/Client.ts'
+import { AccessToken } from '../models/AccessToken.ts'
+import { RefreshToken } from '../models/RefreshToken.ts'
+import { OAuthError } from '../errors/OAuthError.ts'
+
+/**
+ * Refresh Token grant — exchange a refresh token for a new token pair.
+ * Revokes the old access + refresh tokens and issues new ones.
+ */
+export class RefreshTokenGrant implements GrantHandler {
+  readonly grantType = 'refresh_token'
+
+  constructor(
+    private readonly signer: JwtSigner,
+    private readonly server: OAuthServer,
+  ) {}
+
+  async handle(request: MantiqRequest): Promise<OAuthTokenResponse> {
+    const refreshTokenId = await request.input('refresh_token') as string | undefined
+    const clientId = await request.input('client_id') as string | undefined
+    const clientSecret = await request.input('client_secret') as string | undefined
+    const scopeParam = await request.input('scope') as string | undefined
+
+    if (!refreshTokenId) throw new OAuthError('The refresh_token parameter is required.', 'invalid_request')
+    if (!clientId) throw new OAuthError('The client_id parameter is required.', 'invalid_request')
+
+    // Resolve client
+    const client = await Client.find(clientId)
+    if (!client) throw new OAuthError('Client not found.', 'invalid_client', 401)
+
+    // Verify secret for confidential clients
+    if (client.confidential()) {
+      if (!clientSecret || clientSecret !== client.getAttribute('secret')) {
+        throw new OAuthError('Invalid client credentials.', 'invalid_client', 401)
+      }
+    }
+
+    // Resolve refresh token
+    const refreshToken = await RefreshToken.find(refreshTokenId)
+    if (!refreshToken) throw new OAuthError('Invalid refresh token.', 'invalid_grant')
+
+    if (refreshToken.getAttribute('revoked')) {
+      throw new OAuthError('Refresh token has been revoked.', 'invalid_grant')
+    }
+
+    // Check expiration
+    const expiresAt = refreshToken.getAttribute('expires_at')
+    if (expiresAt && new Date(expiresAt) < new Date()) {
+      throw new OAuthError('Refresh token has expired.', 'invalid_grant')
+    }
+
+    // Resolve the original access token
+    const oldAccessTokenId = refreshToken.getAttribute('access_token_id') as string
+    const oldAccessToken = await AccessToken.find(oldAccessTokenId)
+    if (!oldAccessToken) throw new OAuthError('Associated access token not found.', 'invalid_grant')
+
+    // Verify the token belongs to this client
+    if (oldAccessToken.getAttribute('client_id') !== clientId) {
+      throw new OAuthError('Refresh token does not belong to this client.', 'invalid_grant')
+    }
+
+    // Revoke old tokens
+    await refreshToken.revoke()
+    if (!oldAccessToken.getAttribute('revoked')) {
+      await oldAccessToken.revoke()
+    }
+
+    // Determine scopes (keep original scopes, or narrow if requested)
+    const originalScopes = (oldAccessToken.getAttribute('scopes') as string[]) || []
+    let scopes = originalScopes
+
+    if (scopeParam) {
+      const requestedScopes = scopeParam.split(' ').filter(Boolean)
+      // Can only request a subset of original scopes
+      for (const scope of requestedScopes) {
+        if (!originalScopes.includes('*') && !originalScopes.includes(scope)) {
+          throw new OAuthError(`Scope "${scope}" was not granted on the original token.`, 'invalid_scope')
+        }
+      }
+      scopes = requestedScopes
+    }
+
+    // Issue new tokens
+    const userId = oldAccessToken.getAttribute('user_id') as string | null
+    const tokenId = crypto.randomUUID()
+    const now = Math.floor(Date.now() / 1000)
+
+    await AccessToken.create({
+      id: tokenId,
+      user_id: userId,
+      client_id: clientId,
+      name: null,
+      scopes: JSON.stringify(scopes),
+      revoked: false,
+      expires_at: new Date((now + this.server.tokenLifetime) * 1000).toISOString(),
+    })
+
+    const newRefreshTokenId = crypto.randomUUID()
+    await RefreshToken.create({
+      id: newRefreshTokenId,
+      access_token_id: tokenId,
+      revoked: false,
+      expires_at: new Date((now + this.server.refreshTokenLifetime) * 1000).toISOString(),
+    })
+
+    // Sign JWT
+    const jwt = await this.signer.sign({
+      iss: 'mantiq-oauth',
+      sub: userId ?? undefined,
+      aud: clientId,
+      exp: now + this.server.tokenLifetime,
+      iat: now,
+      jti: tokenId,
+      scopes,
+    })
+
+    return {
+      token_type: 'Bearer',
+      expires_in: this.server.tokenLifetime,
+      access_token: jwt,
+      refresh_token: newRefreshTokenId,
+      scope: scopes.join(' '),
+    }
+  }
+}

--- a/packages/oauth/src/guards/JwtGuard.ts
+++ b/packages/oauth/src/guards/JwtGuard.ts
@@ -1,0 +1,95 @@
+import type { Guard } from '@mantiq/auth'
+import type { Authenticatable, UserProvider } from '@mantiq/auth'
+import type { MantiqRequest } from '@mantiq/core'
+import type { JwtSigner } from '../jwt/JwtSigner.ts'
+import { AccessToken } from '../models/AccessToken.ts'
+
+/**
+ * JWT-based stateless guard for OAuth access tokens.
+ * Extracts the bearer token, verifies the JWT signature,
+ * checks the token record in the database, and resolves the user.
+ */
+export class JwtGuard implements Guard {
+  private _user: Authenticatable | null = null
+  private _request: MantiqRequest | null = null
+  private _resolved = false
+
+  constructor(
+    private readonly signer: JwtSigner,
+    private readonly provider: UserProvider,
+  ) {}
+
+  async check(): Promise<boolean> {
+    return (await this.user()) !== null
+  }
+
+  async guest(): Promise<boolean> {
+    return !(await this.check())
+  }
+
+  async user(): Promise<Authenticatable | null> {
+    if (this._resolved) return this._user
+    this._resolved = true
+
+    if (!this._request) return null
+
+    const bearerToken = this._request.bearerToken()
+    if (!bearerToken) return null
+
+    // Verify JWT signature and expiration
+    const payload = await this.signer.verify(bearerToken)
+    if (!payload || !payload.jti) return null
+
+    // Look up the access token in the database
+    const accessToken = await AccessToken.find(payload.jti)
+    if (!accessToken) return null
+
+    // Check if revoked
+    if (accessToken.getAttribute('revoked')) return null
+
+    // Check if expired (belt-and-suspenders — JWT exp is already checked)
+    if (accessToken.isExpired()) return null
+
+    // For client_credentials tokens with no user
+    const userId = payload.sub
+    if (!userId) return null
+
+    // Resolve user from provider
+    const user = await this.provider.retrieveById(userId)
+    if (!user) return null
+
+    // Attach token info to the user if it supports it
+    if (typeof (user as any).withAccessToken === 'function') {
+      (user as any).withAccessToken(accessToken)
+    }
+
+    this._user = user
+    return user
+  }
+
+  async id(): Promise<string | number | null> {
+    const user = await this.user()
+    return user?.getAuthIdentifier() ?? null
+  }
+
+  async validate(credentials: Record<string, any>): Promise<boolean> {
+    const user = await this.provider.retrieveByCredentials(credentials)
+    if (!user) return false
+    return this.provider.validateCredentials(user, credentials)
+  }
+
+  setUser(user: Authenticatable): void {
+    this._user = user
+    this._resolved = true
+  }
+
+  hasUser(): boolean {
+    return this._user !== null
+  }
+
+  setRequest(request: MantiqRequest): void {
+    this._request = request
+    this._user = null
+    this._resolved = false
+  }
+}

--- a/packages/oauth/src/helpers/oauth.ts
+++ b/packages/oauth/src/helpers/oauth.ts
@@ -1,0 +1,15 @@
+import { Application } from '@mantiq/core'
+import type { OAuthServer } from '../OAuthServer.ts'
+
+export const OAUTH_SERVER = Symbol('OAuthServer')
+
+/**
+ * Access the OAuthServer singleton.
+ *
+ * @example
+ *   const server = oauth()
+ *   server.tokensCan({ 'read': 'Read data', 'write': 'Write data' })
+ */
+export function oauth(): OAuthServer {
+  return Application.getInstance().make<OAuthServer>(OAUTH_SERVER)
+}

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -1,0 +1,58 @@
+// ── JWT ──────────────────────────────────────────────────────────────────────
+export type { JwtPayload } from './jwt/JwtPayload.ts'
+export { base64UrlEncode, base64UrlDecode, base64UrlEncodeString, base64UrlDecodeString } from './jwt/JwtEncoder.ts'
+export { JwtSigner } from './jwt/JwtSigner.ts'
+
+// ── Models ───────────────────────────────────────────────────────────────────
+export { Client } from './models/Client.ts'
+export { AccessToken } from './models/AccessToken.ts'
+export { AuthCode } from './models/AuthCode.ts'
+export { RefreshToken } from './models/RefreshToken.ts'
+
+// ── Server ───────────────────────────────────────────────────────────────────
+export { OAuthServer } from './OAuthServer.ts'
+export type { OAuthConfig } from './OAuthServer.ts'
+
+// ── Grants ───────────────────────────────────────────────────────────────────
+export type { GrantHandler, OAuthTokenResponse } from './grants/GrantHandler.ts'
+export { AuthCodeGrant } from './grants/AuthCodeGrant.ts'
+export { ClientCredentialsGrant } from './grants/ClientCredentialsGrant.ts'
+export { RefreshTokenGrant } from './grants/RefreshTokenGrant.ts'
+export { PersonalAccessGrant } from './grants/PersonalAccessGrant.ts'
+
+// ── Guards ───────────────────────────────────────────────────────────────────
+export { JwtGuard } from './guards/JwtGuard.ts'
+
+// ── Middleware ────────────────────────────────────────────────────────────────
+export { CheckScopes } from './middleware/CheckScopes.ts'
+export { CheckForAnyScope } from './middleware/CheckForAnyScope.ts'
+export { CheckClientCredentials } from './middleware/CheckClientCredentials.ts'
+
+// ── Routes ───────────────────────────────────────────────────────────────────
+export { oauthRoutes } from './routes/oauthRoutes.ts'
+export type { OAuthRouteOptions } from './routes/oauthRoutes.ts'
+export { TokenController } from './routes/TokenController.ts'
+export { AuthorizationController } from './routes/AuthorizationController.ts'
+export { ClientController } from './routes/ClientController.ts'
+export { ScopeController } from './routes/ScopeController.ts'
+
+// ── Commands ─────────────────────────────────────────────────────────────────
+export { OAuthInstallCommand } from './commands/OAuthInstallCommand.ts'
+export { OAuthKeysCommand } from './commands/OAuthKeysCommand.ts'
+export { OAuthClientCommand } from './commands/OAuthClientCommand.ts'
+export { OAuthPurgeCommand } from './commands/OAuthPurgeCommand.ts'
+
+// ── Migrations ───────────────────────────────────────────────────────────────
+export { CreateOAuthClientsTable } from './migrations/CreateOAuthClientsTable.ts'
+export { CreateOAuthAccessTokensTable } from './migrations/CreateOAuthAccessTokensTable.ts'
+export { CreateOAuthAuthCodesTable } from './migrations/CreateOAuthAuthCodesTable.ts'
+export { CreateOAuthRefreshTokensTable } from './migrations/CreateOAuthRefreshTokensTable.ts'
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+export { OAuthError } from './errors/OAuthError.ts'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+export { oauth, OAUTH_SERVER } from './helpers/oauth.ts'
+
+// ── Service Provider ─────────────────────────────────────────────────────────
+export { OAuthServiceProvider } from './OAuthServiceProvider.ts'

--- a/packages/oauth/src/jwt/JwtEncoder.ts
+++ b/packages/oauth/src/jwt/JwtEncoder.ts
@@ -1,0 +1,51 @@
+/**
+ * Base64URL encode/decode utilities for JWT.
+ * No external dependencies — uses standard APIs only.
+ */
+
+/**
+ * Encode a Uint8Array to a Base64URL string (no padding).
+ */
+export function base64UrlEncode(data: Uint8Array): string {
+  let binary = ''
+  for (let i = 0; i < data.length; i++) {
+    binary += String.fromCharCode(data[i]!)
+  }
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+/**
+ * Decode a Base64URL string to a Uint8Array.
+ */
+export function base64UrlDecode(str: string): Uint8Array {
+  // Restore standard Base64 characters
+  let base64 = str.replace(/-/g, '+').replace(/_/g, '/')
+  // Restore padding
+  const pad = base64.length % 4
+  if (pad === 2) base64 += '=='
+  else if (pad === 3) base64 += '='
+
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+/**
+ * Encode a UTF-8 string to Base64URL.
+ */
+export function base64UrlEncodeString(str: string): string {
+  return base64UrlEncode(new TextEncoder().encode(str))
+}
+
+/**
+ * Decode a Base64URL string to a UTF-8 string.
+ */
+export function base64UrlDecodeString(str: string): string {
+  return new TextDecoder().decode(base64UrlDecode(str))
+}

--- a/packages/oauth/src/jwt/JwtPayload.ts
+++ b/packages/oauth/src/jwt/JwtPayload.ts
@@ -1,0 +1,9 @@
+export interface JwtPayload {
+  iss?: string
+  sub?: string
+  aud?: string
+  exp?: number
+  iat?: number
+  jti?: string
+  scopes?: string[]
+}

--- a/packages/oauth/src/jwt/JwtSigner.ts
+++ b/packages/oauth/src/jwt/JwtSigner.ts
@@ -1,0 +1,175 @@
+import type { JwtPayload } from './JwtPayload.ts'
+import { base64UrlEncode, base64UrlDecode, base64UrlEncodeString } from './JwtEncoder.ts'
+
+const ALGORITHM: RsaHashedImportParams = {
+  name: 'RSASSA-PKCS1-v1_5',
+  hash: 'SHA-256',
+}
+
+/**
+ * RS256 JWT signer/verifier using the Web Crypto API.
+ * No external dependencies.
+ */
+export class JwtSigner {
+  private privateKey: CryptoKey | null = null
+  private publicKey: CryptoKey | null = null
+
+  /**
+   * Import RSA keys from PEM strings.
+   */
+  async loadKeys(privatePem: string, publicPem: string): Promise<void> {
+    this.privateKey = await importPrivateKey(privatePem)
+    this.publicKey = await importPublicKey(publicPem)
+  }
+
+  /**
+   * Create a signed JWT string (header.payload.signature).
+   */
+  async sign(payload: JwtPayload): Promise<string> {
+    if (!this.privateKey) {
+      throw new Error('Private key not loaded. Call loadKeys() first.')
+    }
+
+    // Auto-set iat if not provided
+    if (!payload.iat) {
+      payload = { ...payload, iat: Math.floor(Date.now() / 1000) }
+    }
+
+    const header = { alg: 'RS256', typ: 'JWT' }
+    const headerEncoded = base64UrlEncodeString(JSON.stringify(header))
+    const payloadEncoded = base64UrlEncodeString(JSON.stringify(payload))
+
+    const signingInput = `${headerEncoded}.${payloadEncoded}`
+    const data = new TextEncoder().encode(signingInput)
+
+    const signature = await crypto.subtle.sign(
+      ALGORITHM.name,
+      this.privateKey,
+      data,
+    )
+
+    const signatureEncoded = base64UrlEncode(new Uint8Array(signature))
+    return `${signingInput}.${signatureEncoded}`
+  }
+
+  /**
+   * Verify a JWT token and return the decoded payload.
+   * Returns null if the token is invalid or expired.
+   */
+  async verify(token: string): Promise<JwtPayload | null> {
+    if (!this.publicKey) {
+      throw new Error('Public key not loaded. Call loadKeys() first.')
+    }
+
+    const parts = token.split('.')
+    if (parts.length !== 3) return null
+
+    const [headerEncoded, payloadEncoded, signatureEncoded] = parts as [string, string, string]
+
+    try {
+      const signingInput = `${headerEncoded}.${payloadEncoded}`
+      const data = new TextEncoder().encode(signingInput)
+      const signature = base64UrlDecode(signatureEncoded)
+
+      const valid = await crypto.subtle.verify(
+        ALGORITHM.name,
+        this.publicKey,
+        signature,
+        data,
+      )
+
+      if (!valid) return null
+
+      const payloadJson = new TextDecoder().decode(base64UrlDecode(payloadEncoded))
+      const payload: JwtPayload = JSON.parse(payloadJson)
+
+      // Check expiration
+      if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
+        return null
+      }
+
+      return payload
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Generate a new RSA key pair and return as PEM strings.
+   */
+  async generateKeyPair(): Promise<{ privateKey: string; publicKey: string }> {
+    const keyPair = await crypto.subtle.generateKey(
+      {
+        name: 'RSASSA-PKCS1-v1_5',
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+        hash: 'SHA-256',
+      },
+      true, // extractable
+      ['sign', 'verify'],
+    )
+
+    const privateDer = await crypto.subtle.exportKey('pkcs8', keyPair.privateKey)
+    const publicDer = await crypto.subtle.exportKey('spki', keyPair.publicKey)
+
+    return {
+      privateKey: derToPem(privateDer, 'PRIVATE'),
+      publicKey: derToPem(publicDer, 'PUBLIC'),
+    }
+  }
+}
+
+// ── PEM helpers ────────────────────────────────────────────────────────────────
+
+function pemToDer(pem: string): ArrayBuffer {
+  const lines = pem.split('\n').filter(
+    (line) => !line.startsWith('-----') && line.trim().length > 0,
+  )
+  const base64 = lines.join('')
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes.buffer
+}
+
+function derToPem(der: ArrayBuffer, type: 'PRIVATE' | 'PUBLIC'): string {
+  const bytes = new Uint8Array(der)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!)
+  }
+  const base64 = btoa(binary)
+
+  // Wrap at 64 characters
+  const lines: string[] = []
+  for (let i = 0; i < base64.length; i += 64) {
+    lines.push(base64.slice(i, i + 64))
+  }
+
+  const label = type === 'PRIVATE' ? 'PRIVATE KEY' : 'PUBLIC KEY'
+  return `-----BEGIN ${label}-----\n${lines.join('\n')}\n-----END ${label}-----`
+}
+
+async function importPrivateKey(pem: string): Promise<CryptoKey> {
+  const der = pemToDer(pem)
+  return crypto.subtle.importKey(
+    'pkcs8',
+    der,
+    ALGORITHM,
+    false,
+    ['sign'],
+  )
+}
+
+async function importPublicKey(pem: string): Promise<CryptoKey> {
+  const der = pemToDer(pem)
+  return crypto.subtle.importKey(
+    'spki',
+    der,
+    ALGORITHM,
+    false,
+    ['verify'],
+  )
+}

--- a/packages/oauth/src/middleware/CheckClientCredentials.ts
+++ b/packages/oauth/src/middleware/CheckClientCredentials.ts
@@ -1,0 +1,60 @@
+import type { MantiqRequest } from '@mantiq/core'
+import type { JwtSigner } from '../jwt/JwtSigner.ts'
+import { AccessToken } from '../models/AccessToken.ts'
+
+/**
+ * Middleware for client_credentials grant tokens.
+ * These tokens have no user — just a client.
+ * Validates the JWT and checks that the token exists and has the required scopes.
+ *
+ * Usage in route middleware: 'client:read,write'
+ */
+export class CheckClientCredentials {
+  private scopes: string[] = []
+
+  constructor(private readonly signer: JwtSigner) {}
+
+  setParameters(...scopes: string[]): void {
+    this.scopes = scopes
+  }
+
+  async handle(request: MantiqRequest, next: () => Promise<Response>): Promise<Response> {
+    const bearerToken = request.bearerToken()
+    if (!bearerToken) {
+      return new Response(
+        JSON.stringify({ message: 'Unauthenticated.' }),
+        { status: 401, headers: { 'Content-Type': 'application/json' } },
+      )
+    }
+
+    // Verify JWT
+    const payload = await this.signer.verify(bearerToken)
+    if (!payload || !payload.jti) {
+      return new Response(
+        JSON.stringify({ message: 'Invalid token.' }),
+        { status: 401, headers: { 'Content-Type': 'application/json' } },
+      )
+    }
+
+    // Look up the access token
+    const accessToken = await AccessToken.find(payload.jti)
+    if (!accessToken || accessToken.getAttribute('revoked') || accessToken.isExpired()) {
+      return new Response(
+        JSON.stringify({ message: 'Token is invalid or expired.' }),
+        { status: 401, headers: { 'Content-Type': 'application/json' } },
+      )
+    }
+
+    // Check required scopes
+    for (const scope of this.scopes) {
+      if (accessToken.cant(scope)) {
+        return new Response(
+          JSON.stringify({ message: `Missing scope: ${scope}` }),
+          { status: 403, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+    }
+
+    return next()
+  }
+}

--- a/packages/oauth/src/middleware/CheckForAnyScope.ts
+++ b/packages/oauth/src/middleware/CheckForAnyScope.ts
@@ -1,0 +1,52 @@
+import type { MantiqRequest } from '@mantiq/core'
+import { AccessToken } from '../models/AccessToken.ts'
+
+/**
+ * Middleware that requires at least ONE of the listed scopes on the JWT token.
+ *
+ * Usage in route middleware: 'scope:read,write'
+ */
+export class CheckForAnyScope {
+  private scopes: string[] = []
+
+  setParameters(...scopes: string[]): void {
+    this.scopes = scopes
+  }
+
+  async handle(request: MantiqRequest, next: () => Promise<Response>): Promise<Response> {
+    const user = request.user<any>()
+    if (!user) {
+      return new Response(
+        JSON.stringify({ message: 'Unauthenticated.' }),
+        { status: 401, headers: { 'Content-Type': 'application/json' } },
+      )
+    }
+
+    // Get the access token from the user
+    const token = this.resolveToken(user)
+    if (!token) {
+      return new Response(
+        JSON.stringify({ message: 'Token not found.' }),
+        { status: 403, headers: { 'Content-Type': 'application/json' } },
+      )
+    }
+
+    const hasAny = this.scopes.some((scope) => token.can(scope))
+    if (!hasAny) {
+      return new Response(
+        JSON.stringify({ message: 'Insufficient scopes.' }),
+        { status: 403, headers: { 'Content-Type': 'application/json' } },
+      )
+    }
+
+    return next()
+  }
+
+  private resolveToken(user: any): AccessToken | null {
+    if (typeof user.currentAccessToken === 'function') {
+      return user.currentAccessToken() as AccessToken | null
+    }
+    if (user._accessToken) return user._accessToken as AccessToken
+    return null
+  }
+}

--- a/packages/oauth/src/middleware/CheckScopes.ts
+++ b/packages/oauth/src/middleware/CheckScopes.ts
@@ -1,0 +1,53 @@
+import type { MantiqRequest } from '@mantiq/core'
+import { AccessToken } from '../models/AccessToken.ts'
+
+/**
+ * Middleware that requires ALL listed scopes on the JWT token.
+ *
+ * Usage in route middleware: 'scopes:read,write'
+ */
+export class CheckScopes {
+  private scopes: string[] = []
+
+  setParameters(...scopes: string[]): void {
+    this.scopes = scopes
+  }
+
+  async handle(request: MantiqRequest, next: () => Promise<Response>): Promise<Response> {
+    const user = request.user<any>()
+    if (!user) {
+      return new Response(
+        JSON.stringify({ message: 'Unauthenticated.' }),
+        { status: 401, headers: { 'Content-Type': 'application/json' } },
+      )
+    }
+
+    // Get the access token from the user
+    const token = this.resolveToken(user)
+    if (!token) {
+      return new Response(
+        JSON.stringify({ message: 'Token not found.' }),
+        { status: 403, headers: { 'Content-Type': 'application/json' } },
+      )
+    }
+
+    for (const scope of this.scopes) {
+      if (token.cant(scope)) {
+        return new Response(
+          JSON.stringify({ message: `Missing scope: ${scope}` }),
+          { status: 403, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+    }
+
+    return next()
+  }
+
+  private resolveToken(user: any): AccessToken | null {
+    if (typeof user.currentAccessToken === 'function') {
+      return user.currentAccessToken() as AccessToken | null
+    }
+    if (user._accessToken) return user._accessToken as AccessToken
+    return null
+  }
+}

--- a/packages/oauth/src/migrations/CreateOAuthAccessTokensTable.ts
+++ b/packages/oauth/src/migrations/CreateOAuthAccessTokensTable.ts
@@ -1,0 +1,21 @@
+import { Migration } from '@mantiq/database'
+import type { SchemaBuilder } from '@mantiq/database'
+
+export class CreateOAuthAccessTokensTable extends Migration {
+  override async up(schema: SchemaBuilder): Promise<void> {
+    await schema.create('oauth_access_tokens', (table) => {
+      table.uuid('id').primary()
+      table.string('user_id').nullable()
+      table.uuid('client_id').nullable()
+      table.string('name').nullable()
+      table.json('scopes').nullable()
+      table.boolean('revoked').default(false)
+      table.timestamp('expires_at').nullable()
+      table.timestamps()
+    })
+  }
+
+  override async down(schema: SchemaBuilder): Promise<void> {
+    await schema.dropIfExists('oauth_access_tokens')
+  }
+}

--- a/packages/oauth/src/migrations/CreateOAuthAuthCodesTable.ts
+++ b/packages/oauth/src/migrations/CreateOAuthAuthCodesTable.ts
@@ -1,0 +1,22 @@
+import { Migration } from '@mantiq/database'
+import type { SchemaBuilder } from '@mantiq/database'
+
+export class CreateOAuthAuthCodesTable extends Migration {
+  override async up(schema: SchemaBuilder): Promise<void> {
+    await schema.create('oauth_auth_codes', (table) => {
+      table.uuid('id').primary()
+      table.string('user_id')
+      table.uuid('client_id')
+      table.json('scopes').nullable()
+      table.boolean('revoked').default(false)
+      table.timestamp('expires_at').nullable()
+      table.string('code_challenge').nullable()
+      table.string('code_challenge_method').nullable()
+      table.timestamps()
+    })
+  }
+
+  override async down(schema: SchemaBuilder): Promise<void> {
+    await schema.dropIfExists('oauth_auth_codes')
+  }
+}

--- a/packages/oauth/src/migrations/CreateOAuthClientsTable.ts
+++ b/packages/oauth/src/migrations/CreateOAuthClientsTable.ts
@@ -1,0 +1,24 @@
+import { Migration } from '@mantiq/database'
+import type { SchemaBuilder } from '@mantiq/database'
+
+export class CreateOAuthClientsTable extends Migration {
+  override async up(schema: SchemaBuilder): Promise<void> {
+    await schema.create('oauth_clients', (table) => {
+      table.uuid('id').primary()
+      table.string('user_id').nullable()
+      table.string('name')
+      table.string('secret', 100).nullable()
+      table.string('redirect')
+      table.json('grant_types').nullable()
+      table.json('scopes').nullable()
+      table.boolean('personal_access_client').default(false)
+      table.boolean('password_client').default(false)
+      table.boolean('revoked').default(false)
+      table.timestamps()
+    })
+  }
+
+  override async down(schema: SchemaBuilder): Promise<void> {
+    await schema.dropIfExists('oauth_clients')
+  }
+}

--- a/packages/oauth/src/migrations/CreateOAuthRefreshTokensTable.ts
+++ b/packages/oauth/src/migrations/CreateOAuthRefreshTokensTable.ts
@@ -1,0 +1,18 @@
+import { Migration } from '@mantiq/database'
+import type { SchemaBuilder } from '@mantiq/database'
+
+export class CreateOAuthRefreshTokensTable extends Migration {
+  override async up(schema: SchemaBuilder): Promise<void> {
+    await schema.create('oauth_refresh_tokens', (table) => {
+      table.uuid('id').primary()
+      table.uuid('access_token_id')
+      table.boolean('revoked').default(false)
+      table.timestamp('expires_at').nullable()
+      table.timestamps()
+    })
+  }
+
+  override async down(schema: SchemaBuilder): Promise<void> {
+    await schema.dropIfExists('oauth_refresh_tokens')
+  }
+}

--- a/packages/oauth/src/models/AccessToken.ts
+++ b/packages/oauth/src/models/AccessToken.ts
@@ -1,0 +1,52 @@
+import { Model } from '@mantiq/database'
+
+export class AccessToken extends Model {
+  static override table = 'oauth_access_tokens'
+  static override keyType = 'string' as const
+  static override incrementing = false
+  static override fillable = [
+    'user_id',
+    'client_id',
+    'name',
+    'scopes',
+    'revoked',
+    'expires_at',
+  ]
+  static override casts = {
+    scopes: 'json' as const,
+    revoked: 'boolean' as const,
+  }
+
+  /**
+   * Check if the token has the given scope.
+   */
+  can(scope: string): boolean {
+    const scopes = this.getAttribute('scopes') as string[] | null
+    if (!scopes) return false
+    return scopes.includes('*') || scopes.includes(scope)
+  }
+
+  /**
+   * Check if the token does NOT have the given scope.
+   */
+  cant(scope: string): boolean {
+    return !this.can(scope)
+  }
+
+  /**
+   * Revoke the access token.
+   */
+  async revoke(): Promise<void> {
+    this.setAttribute('revoked', true)
+    await this.save()
+  }
+
+  /**
+   * Check if the token has expired.
+   */
+  isExpired(): boolean {
+    const expiresAt = this.getAttribute('expires_at')
+    if (!expiresAt) return false
+    return new Date(expiresAt) < new Date()
+  }
+}

--- a/packages/oauth/src/models/AuthCode.ts
+++ b/packages/oauth/src/models/AuthCode.ts
@@ -1,0 +1,20 @@
+import { Model } from '@mantiq/database'
+
+export class AuthCode extends Model {
+  static override table = 'oauth_auth_codes'
+  static override keyType = 'string' as const
+  static override incrementing = false
+  static override fillable = [
+    'user_id',
+    'client_id',
+    'scopes',
+    'revoked',
+    'expires_at',
+    'code_challenge',
+    'code_challenge_method',
+  ]
+  static override casts = {
+    scopes: 'json' as const,
+    revoked: 'boolean' as const,
+  }
+}

--- a/packages/oauth/src/models/Client.ts
+++ b/packages/oauth/src/models/Client.ts
@@ -1,0 +1,36 @@
+import { Model } from '@mantiq/database'
+
+export class Client extends Model {
+  static override table = 'oauth_clients'
+  static override keyType = 'string' as const
+  static override incrementing = false
+  static override fillable = [
+    'name',
+    'secret',
+    'redirect',
+    'personal_access_client',
+    'password_client',
+  ]
+  static override hidden = ['secret']
+  static override casts = {
+    grant_types: 'json' as const,
+    scopes: 'json' as const,
+    personal_access_client: 'boolean' as const,
+    password_client: 'boolean' as const,
+    revoked: 'boolean' as const,
+  }
+
+  /**
+   * Check if the client is a confidential client (has a secret).
+   */
+  confidential(): boolean {
+    return !!this.getAttribute('secret')
+  }
+
+  /**
+   * Check if the client is a first-party (personal access) client.
+   */
+  firstParty(): boolean {
+    return !!this.getAttribute('personal_access_client')
+  }
+}

--- a/packages/oauth/src/models/RefreshToken.ts
+++ b/packages/oauth/src/models/RefreshToken.ts
@@ -1,0 +1,23 @@
+import { Model } from '@mantiq/database'
+
+export class RefreshToken extends Model {
+  static override table = 'oauth_refresh_tokens'
+  static override keyType = 'string' as const
+  static override incrementing = false
+  static override fillable = [
+    'access_token_id',
+    'revoked',
+    'expires_at',
+  ]
+  static override casts = {
+    revoked: 'boolean' as const,
+  }
+
+  /**
+   * Revoke the refresh token.
+   */
+  async revoke(): Promise<void> {
+    this.setAttribute('revoked', true)
+    await this.save()
+  }
+}

--- a/packages/oauth/src/routes/AuthorizationController.ts
+++ b/packages/oauth/src/routes/AuthorizationController.ts
@@ -1,0 +1,132 @@
+import type { MantiqRequest } from '@mantiq/core'
+import type { OAuthServer } from '../OAuthServer.ts'
+import { Client } from '../models/Client.ts'
+import { AuthCode } from '../models/AuthCode.ts'
+import { OAuthError } from '../errors/OAuthError.ts'
+
+/**
+ * Handles the authorization code flow endpoints:
+ * - GET  /oauth/authorize — show authorization form / validate params
+ * - POST /oauth/authorize — approve the authorization request
+ * - DELETE /oauth/authorize — deny the authorization request
+ */
+export class AuthorizationController {
+  constructor(private readonly server: OAuthServer) {}
+
+  /**
+   * GET /oauth/authorize
+   * Validates the authorization request parameters and returns client info + requested scopes.
+   */
+  async authorize(request: MantiqRequest): Promise<Response> {
+    const clientId = request.query('client_id')
+    const redirectUri = request.query('redirect_uri')
+    const responseType = request.query('response_type')
+    const scopeParam = request.query('scope')
+    const state = request.query('state')
+
+    if (!clientId) throw new OAuthError('The client_id parameter is required.', 'invalid_request')
+    if (!redirectUri) throw new OAuthError('The redirect_uri parameter is required.', 'invalid_request')
+    if (responseType !== 'code') throw new OAuthError('Only response_type=code is supported.', 'unsupported_response_type')
+
+    const client = await Client.find(clientId)
+    if (!client) throw new OAuthError('Client not found.', 'invalid_client')
+
+    // Validate redirect URI
+    const allowedRedirect = client.getAttribute('redirect') as string
+    if (allowedRedirect && redirectUri !== allowedRedirect) {
+      throw new OAuthError('Invalid redirect URI.', 'invalid_request')
+    }
+
+    const scopes = scopeParam ? scopeParam.split(' ').filter(Boolean) : []
+    const scopeDetails = scopes.map((s) => ({
+      id: s,
+      description: this.server.scopes().find((sc) => sc.id === s)?.description ?? s,
+    }))
+
+    return new Response(JSON.stringify({
+      client: {
+        id: client.getKey(),
+        name: client.getAttribute('name'),
+      },
+      scopes: scopeDetails,
+      state,
+      redirect_uri: redirectUri,
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  /**
+   * POST /oauth/authorize
+   * Approve the authorization request and issue an authorization code.
+   */
+  async approve(request: MantiqRequest): Promise<Response> {
+    const user = request.user<any>()
+    if (!user) throw new OAuthError('User must be authenticated.', 'invalid_request', 401)
+
+    const clientId = await request.input('client_id') as string | undefined
+    const redirectUri = await request.input('redirect_uri') as string | undefined
+    const scopeParam = await request.input('scope') as string | undefined
+    const state = await request.input('state') as string | undefined
+    const codeChallenge = await request.input('code_challenge') as string | undefined
+    const codeChallengeMethod = await request.input('code_challenge_method') as string | undefined
+
+    if (!clientId) throw new OAuthError('The client_id parameter is required.', 'invalid_request')
+    if (!redirectUri) throw new OAuthError('The redirect_uri parameter is required.', 'invalid_request')
+
+    const client = await Client.find(clientId)
+    if (!client) throw new OAuthError('Client not found.', 'invalid_client')
+
+    const userId = typeof user.getAuthIdentifier === 'function'
+      ? user.getAuthIdentifier()
+      : user.id ?? user.getAttribute?.('id')
+
+    const scopes = scopeParam ? scopeParam.split(' ').filter(Boolean) : []
+    const codeId = crypto.randomUUID()
+    const now = new Date()
+    const expiresAt = new Date(now.getTime() + 10 * 60 * 1000) // 10 minutes
+
+    await AuthCode.create({
+      id: codeId,
+      user_id: String(userId),
+      client_id: clientId,
+      scopes: JSON.stringify(scopes),
+      revoked: false,
+      expires_at: expiresAt.toISOString(),
+      code_challenge: codeChallenge ?? null,
+      code_challenge_method: codeChallengeMethod ?? null,
+    })
+
+    // Build redirect URL with code
+    const url = new URL(redirectUri)
+    url.searchParams.set('code', codeId)
+    if (state) url.searchParams.set('state', state)
+
+    return new Response(null, {
+      status: 302,
+      headers: { 'Location': url.toString() },
+    })
+  }
+
+  /**
+   * DELETE /oauth/authorize
+   * Deny the authorization request.
+   */
+  async deny(request: MantiqRequest): Promise<Response> {
+    const redirectUri = await request.input('redirect_uri') as string | undefined
+    const state = await request.input('state') as string | undefined
+
+    if (!redirectUri) throw new OAuthError('The redirect_uri parameter is required.', 'invalid_request')
+
+    const url = new URL(redirectUri)
+    url.searchParams.set('error', 'access_denied')
+    url.searchParams.set('error_description', 'The user denied the authorization request.')
+    if (state) url.searchParams.set('state', state)
+
+    return new Response(null, {
+      status: 302,
+      headers: { 'Location': url.toString() },
+    })
+  }
+}

--- a/packages/oauth/src/routes/ClientController.ts
+++ b/packages/oauth/src/routes/ClientController.ts
@@ -1,0 +1,138 @@
+import type { MantiqRequest } from '@mantiq/core'
+import { Client } from '../models/Client.ts'
+import { OAuthError } from '../errors/OAuthError.ts'
+
+/**
+ * CRUD controller for OAuth clients.
+ * All endpoints require authentication.
+ */
+export class ClientController {
+  /**
+   * GET /oauth/clients
+   * List all clients for the authenticated user.
+   */
+  async index(request: MantiqRequest): Promise<Response> {
+    const user = request.user<any>()
+    if (!user) throw new OAuthError('Unauthenticated.', 'invalid_request', 401)
+
+    const userId = typeof user.getAuthIdentifier === 'function'
+      ? user.getAuthIdentifier()
+      : user.id ?? user.getAttribute?.('id')
+
+    const clients = await Client.where('user_id', userId).get()
+    const data = clients.map((c) => c.toJSON())
+
+    return new Response(JSON.stringify(data), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  /**
+   * POST /oauth/clients
+   * Create a new OAuth client.
+   */
+  async store(request: MantiqRequest): Promise<Response> {
+    const user = request.user<any>()
+    if (!user) throw new OAuthError('Unauthenticated.', 'invalid_request', 401)
+
+    const name = await request.input('name') as string | undefined
+    const redirect = await request.input('redirect') as string | undefined
+
+    if (!name) throw new OAuthError('The name field is required.', 'invalid_request')
+    if (!redirect) throw new OAuthError('The redirect field is required.', 'invalid_request')
+
+    const userId = typeof user.getAuthIdentifier === 'function'
+      ? user.getAuthIdentifier()
+      : user.id ?? user.getAttribute?.('id')
+
+    const clientId = crypto.randomUUID()
+    const secret = crypto.randomUUID()
+
+    const client = await Client.create({
+      id: clientId,
+      user_id: String(userId),
+      name,
+      secret,
+      redirect,
+      personal_access_client: false,
+      password_client: false,
+      revoked: false,
+    })
+
+    // Include the secret in the creation response (only time it's visible)
+    const data = {
+      ...client.toJSON(),
+      secret,
+    }
+
+    return new Response(JSON.stringify(data), {
+      status: 201,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  /**
+   * PUT /oauth/clients/:id
+   * Update an existing OAuth client.
+   */
+  async update(request: MantiqRequest): Promise<Response> {
+    const user = request.user<any>()
+    if (!user) throw new OAuthError('Unauthenticated.', 'invalid_request', 401)
+
+    const clientId = request.param('id')
+    if (!clientId) throw new OAuthError('Client ID is required.', 'invalid_request')
+
+    const client = await Client.find(clientId)
+    if (!client) throw new OAuthError('Client not found.', 'invalid_client', 404)
+
+    const userId = typeof user.getAuthIdentifier === 'function'
+      ? user.getAuthIdentifier()
+      : user.id ?? user.getAttribute?.('id')
+
+    if (client.getAttribute('user_id') !== String(userId)) {
+      throw new OAuthError('This client does not belong to you.', 'invalid_client', 403)
+    }
+
+    const name = await request.input('name') as string | undefined
+    const redirect = await request.input('redirect') as string | undefined
+
+    if (name) client.setAttribute('name', name)
+    if (redirect) client.setAttribute('redirect', redirect)
+
+    await client.save()
+
+    return new Response(JSON.stringify(client.toJSON()), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  /**
+   * DELETE /oauth/clients/:id
+   * Delete an OAuth client.
+   */
+  async destroy(request: MantiqRequest): Promise<Response> {
+    const user = request.user<any>()
+    if (!user) throw new OAuthError('Unauthenticated.', 'invalid_request', 401)
+
+    const clientId = request.param('id')
+    if (!clientId) throw new OAuthError('Client ID is required.', 'invalid_request')
+
+    const client = await Client.find(clientId)
+    if (!client) throw new OAuthError('Client not found.', 'invalid_client', 404)
+
+    const userId = typeof user.getAuthIdentifier === 'function'
+      ? user.getAuthIdentifier()
+      : user.id ?? user.getAttribute?.('id')
+
+    if (client.getAttribute('user_id') !== String(userId)) {
+      throw new OAuthError('This client does not belong to you.', 'invalid_client', 403)
+    }
+
+    client.setAttribute('revoked', true)
+    await client.save()
+
+    return new Response(null, { status: 204 })
+  }
+}

--- a/packages/oauth/src/routes/ScopeController.ts
+++ b/packages/oauth/src/routes/ScopeController.ts
@@ -1,0 +1,19 @@
+import type { MantiqRequest } from '@mantiq/core'
+import type { OAuthServer } from '../OAuthServer.ts'
+
+/**
+ * GET /oauth/scopes
+ * Returns all registered OAuth scopes.
+ */
+export class ScopeController {
+  constructor(private readonly server: OAuthServer) {}
+
+  async index(_request: MantiqRequest): Promise<Response> {
+    const scopes = this.server.scopes()
+
+    return new Response(JSON.stringify(scopes), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}

--- a/packages/oauth/src/routes/TokenController.ts
+++ b/packages/oauth/src/routes/TokenController.ts
@@ -1,0 +1,38 @@
+import type { MantiqRequest } from '@mantiq/core'
+import type { GrantHandler, OAuthTokenResponse } from '../grants/GrantHandler.ts'
+import { OAuthError } from '../errors/OAuthError.ts'
+
+/**
+ * POST /oauth/token
+ * Dispatches to the appropriate grant handler based on grant_type.
+ */
+export class TokenController {
+  private readonly grants = new Map<string, GrantHandler>()
+
+  registerGrant(grant: GrantHandler): void {
+    this.grants.set(grant.grantType, grant)
+  }
+
+  async issueToken(request: MantiqRequest): Promise<Response> {
+    const grantType = await request.input('grant_type') as string | undefined
+    if (!grantType) {
+      throw new OAuthError('The grant_type parameter is required.', 'invalid_request')
+    }
+
+    const handler = this.grants.get(grantType)
+    if (!handler) {
+      throw new OAuthError(`Unsupported grant type: ${grantType}`, 'unsupported_grant_type')
+    }
+
+    const tokenResponse: OAuthTokenResponse = await handler.handle(request)
+
+    return new Response(JSON.stringify(tokenResponse), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+        'Pragma': 'no-cache',
+      },
+    })
+  }
+}

--- a/packages/oauth/src/routes/oauthRoutes.ts
+++ b/packages/oauth/src/routes/oauthRoutes.ts
@@ -1,0 +1,55 @@
+import type { Router } from '@mantiq/core'
+import type { OAuthServer } from '../OAuthServer.ts'
+import { TokenController } from './TokenController.ts'
+import { AuthorizationController } from './AuthorizationController.ts'
+import { ClientController } from './ClientController.ts'
+import { ScopeController } from './ScopeController.ts'
+import type { GrantHandler } from '../grants/GrantHandler.ts'
+
+export interface OAuthRouteOptions {
+  server: OAuthServer
+  grants: GrantHandler[]
+}
+
+/**
+ * Register all OAuth routes on a Router instance.
+ */
+export function oauthRoutes(router: Router, options: OAuthRouteOptions): void {
+  const { server, grants } = options
+
+  // Token controller
+  const tokenController = new TokenController()
+  for (const grant of grants) {
+    tokenController.registerGrant(grant)
+  }
+
+  // Authorization controller
+  const authorizationController = new AuthorizationController(server)
+
+  // Client controller
+  const clientController = new ClientController()
+
+  // Scope controller
+  const scopeController = new ScopeController(server)
+
+  // ── Token endpoint (public) ─────────────────────────────────────────────
+  router.post('/oauth/token', (req) => tokenController.issueToken(req))
+
+  // ── Authorization endpoints ─────────────────────────────────────────────
+  router.get('/oauth/authorize', (req) => authorizationController.authorize(req))
+  router.post('/oauth/authorize', (req) => authorizationController.approve(req))
+    .middleware('auth:oauth')
+  router.delete('/oauth/authorize', (req) => authorizationController.deny(req))
+    .middleware('auth:oauth')
+
+  // ── Client CRUD (requires auth) ────────────────────────────────────────
+  router.group({ prefix: '/oauth', middleware: ['auth:oauth'] }, (r) => {
+    r.get('/clients', (req) => clientController.index(req))
+    r.post('/clients', (req) => clientController.store(req))
+    r.put('/clients/:id', (req) => clientController.update(req))
+    r.delete('/clients/:id', (req) => clientController.destroy(req))
+  })
+
+  // ── Scopes endpoint ────────────────────────────────────────────────────
+  router.get('/oauth/scopes', (req) => scopeController.index(req))
+}

--- a/packages/oauth/tests/unit/JwtSigner.test.ts
+++ b/packages/oauth/tests/unit/JwtSigner.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect, beforeAll } from 'bun:test'
+import { JwtSigner } from '../../src/jwt/JwtSigner.ts'
+import type { JwtPayload } from '../../src/jwt/JwtPayload.ts'
+
+describe('JwtSigner', () => {
+  let signer: JwtSigner
+  let privateKeyPem: string
+  let publicKeyPem: string
+
+  beforeAll(async () => {
+    signer = new JwtSigner()
+    const keys = await signer.generateKeyPair()
+    privateKeyPem = keys.privateKey
+    publicKeyPem = keys.publicKey
+    await signer.loadKeys(privateKeyPem, publicKeyPem)
+  })
+
+  test('generateKeyPair returns PEM strings', () => {
+    expect(privateKeyPem).toContain('PRIVATE KEY')
+    expect(publicKeyPem).toContain('PUBLIC KEY')
+  })
+
+  test('sign returns a JWT with 3 parts', async () => {
+    const token = await signer.sign({ sub: '1', scopes: ['read'] })
+    const parts = token.split('.')
+    expect(parts).toHaveLength(3)
+  })
+
+  test('verify returns payload for valid token', async () => {
+    const payload: JwtPayload = { sub: 'user-123', aud: 'client-1', scopes: ['read', 'write'] }
+    const token = await signer.sign(payload)
+    const result = await signer.verify(token)
+    expect(result).not.toBeNull()
+    expect(result!.sub).toBe('user-123')
+    expect(result!.aud).toBe('client-1')
+    expect(result!.scopes).toEqual(['read', 'write'])
+  })
+
+  test('verify sets iat automatically', async () => {
+    const token = await signer.sign({ sub: '1' })
+    const result = await signer.verify(token)
+    expect(typeof result!.iat).toBe('number')
+    expect(result!.iat!).toBeGreaterThan(0)
+  })
+
+  test('verify returns null for expired token', async () => {
+    const token = await signer.sign({ sub: '1', exp: Math.floor(Date.now() / 1000) - 100 })
+    const result = await signer.verify(token)
+    expect(result).toBeNull()
+  })
+
+  test('verify returns null for tampered token', async () => {
+    const token = await signer.sign({ sub: '1' })
+    const tampered = token.slice(0, -5) + 'XXXXX'
+    const result = await signer.verify(tampered)
+    expect(result).toBeNull()
+  })
+
+  test('verify returns null for malformed token', async () => {
+    expect(await signer.verify('not.a.jwt')).toBeNull()
+    expect(await signer.verify('')).toBeNull()
+    expect(await signer.verify('abc')).toBeNull()
+  })
+
+  test('sign with jti preserves it', async () => {
+    const token = await signer.sign({ sub: '1', jti: 'token-uuid-123' })
+    const result = await signer.verify(token)
+    expect(result!.jti).toBe('token-uuid-123')
+  })
+
+  test('different keys cannot verify', async () => {
+    const otherSigner = new JwtSigner()
+    const otherKeys = await otherSigner.generateKeyPair()
+    await otherSigner.loadKeys(otherKeys.privateKey, otherKeys.publicKey)
+
+    const token = await signer.sign({ sub: '1' })
+    const result = await otherSigner.verify(token)
+    expect(result).toBeNull()
+  })
+})

--- a/packages/oauth/tsconfig.json
+++ b/packages/oauth/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "./dist", "rootDir": "./src" },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/social-auth/package.json
+++ b/packages/social-auth/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@mantiq/social-auth",
+  "version": "0.1.0",
+  "description": "Social authentication — login with Google, GitHub, Facebook, Apple, and more via extensible providers",
+  "type": "module",
+  "license": "MIT",
+  "author": "Abdullah Khan",
+  "homepage": "https://github.com/mantiqjs/mantiq/tree/main/packages/social-auth",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mantiqjs/mantiq.git",
+    "directory": "packages/social-auth"
+  },
+  "bugs": {
+    "url": "https://github.com/mantiqjs/mantiq/issues"
+  },
+  "keywords": ["mantiq", "social-auth", "oauth", "google", "github", "facebook", "apple", "login"],
+  "engines": { "bun": ">=1.1.0" },
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": { ".": { "bun": "./src/index.ts", "default": "./src/index.ts" } },
+  "files": ["src/", "package.json", "README.md"],
+  "scripts": {
+    "build": "bun build ./src/index.ts --outdir ./dist --target bun --packages=external",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "peerDependencies": {
+    "@mantiq/core": "^0.2.0"
+  },
+  "devDependencies": {
+    "bun-types": "latest",
+    "typescript": "^5.7.0",
+    "@mantiq/core": "workspace:*"
+  }
+}

--- a/packages/social-auth/src/AbstractProvider.ts
+++ b/packages/social-auth/src/AbstractProvider.ts
@@ -1,0 +1,131 @@
+import type { OAuthProvider } from './contracts/OAuthProvider.ts'
+import type { OAuthUser } from './contracts/OAuthUser.ts'
+
+export interface ProviderConfig {
+  clientId: string
+  clientSecret: string
+  redirectUrl: string
+}
+
+/**
+ * Base class implementing the OAuth 2.0 authorization code flow.
+ *
+ * Subclasses must implement:
+ * - `getAuthUrl()` — the provider's authorization endpoint
+ * - `getTokenUrl()` — the provider's token exchange endpoint
+ * - `getUserByToken(token)` — fetch the raw user profile from the provider
+ * - `mapUserToObject(raw)` — normalize the raw profile into an OAuthUser
+ */
+export abstract class AbstractProvider implements OAuthProvider {
+  abstract readonly name: string
+
+  protected clientId: string
+  protected clientSecret: string
+  protected redirectUrl: string
+  protected _scopes: string[] = []
+  protected _params: Record<string, string> = {}
+  protected _stateless = false
+
+  constructor(config: ProviderConfig) {
+    this.clientId = config.clientId
+    this.clientSecret = config.clientSecret
+    this.redirectUrl = config.redirectUrl
+  }
+
+  // ── Abstract (provider-specific) ─────────────────────────────────────────
+
+  protected abstract getAuthUrl(): string
+  protected abstract getTokenUrl(): string
+  protected abstract getUserByToken(token: string): Promise<Record<string, any>>
+  protected abstract mapUserToObject(raw: Record<string, any>): OAuthUser
+
+  // ── OAuth 2.0 flow ───────────────────────────────────────────────────────
+
+  redirect(): Response {
+    const url = new URL(this.getAuthUrl())
+    url.searchParams.set('client_id', this.clientId)
+    url.searchParams.set('redirect_uri', this.redirectUrl)
+    url.searchParams.set('response_type', 'code')
+    url.searchParams.set('scope', this._scopes.join(' '))
+
+    if (!this._stateless) {
+      const state = crypto.randomUUID()
+      url.searchParams.set('state', state)
+    }
+
+    for (const [k, v] of Object.entries(this._params)) {
+      url.searchParams.set(k, v)
+    }
+
+    return Response.redirect(url.toString(), 302)
+  }
+
+  async user(request: any): Promise<OAuthUser> {
+    const code = typeof request?.query === 'function'
+      ? request.query('code')
+      : new URL(request.url).searchParams.get('code')
+
+    if (!code) {
+      throw new Error('Authorization code not found in callback')
+    }
+
+    const tokenData = await this.getAccessToken(code)
+    const rawUser = await this.getUserByToken(tokenData.access_token)
+    const oauthUser = this.mapUserToObject(rawUser)
+    oauthUser.token = tokenData.access_token
+    oauthUser.refreshToken = tokenData.refresh_token ?? null
+    oauthUser.expiresIn = tokenData.expires_in ?? null
+    return oauthUser
+  }
+
+  async userFromToken(accessToken: string): Promise<OAuthUser> {
+    const raw = await this.getUserByToken(accessToken)
+    const user = this.mapUserToObject(raw)
+    user.token = accessToken
+    return user
+  }
+
+  // ── Token exchange ───────────────────────────────────────────────────────
+
+  protected async getAccessToken(
+    code: string,
+  ): Promise<{ access_token: string; refresh_token?: string; expires_in?: number }> {
+    const res = await fetch(this.getTokenUrl(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        code,
+        redirect_uri: this.redirectUrl,
+      }),
+    })
+
+    if (!res.ok) {
+      throw new Error(`Token exchange failed: ${res.status}`)
+    }
+
+    return res.json() as Promise<{ access_token: string; refresh_token?: string; expires_in?: number }>
+  }
+
+  // ── Fluent configuration ─────────────────────────────────────────────────
+
+  scopes(scopes: string[]): this {
+    this._scopes = scopes
+    return this
+  }
+
+  with(params: Record<string, string>): this {
+    Object.assign(this._params, params)
+    return this
+  }
+
+  stateless(): this {
+    this._stateless = true
+    return this
+  }
+}

--- a/packages/social-auth/src/SocialAuthManager.ts
+++ b/packages/social-auth/src/SocialAuthManager.ts
@@ -1,0 +1,110 @@
+import type { OAuthProvider } from './contracts/OAuthProvider.ts'
+import type { ProviderConfig } from './AbstractProvider.ts'
+import { GoogleProvider } from './providers/GoogleProvider.ts'
+import { GitHubProvider } from './providers/GitHubProvider.ts'
+import { FacebookProvider } from './providers/FacebookProvider.ts'
+import { AppleProvider } from './providers/AppleProvider.ts'
+import { TwitterProvider } from './providers/TwitterProvider.ts'
+import { LinkedInProvider } from './providers/LinkedInProvider.ts'
+import { MicrosoftProvider } from './providers/MicrosoftProvider.ts'
+import { DiscordProvider } from './providers/DiscordProvider.ts'
+
+export interface SocialAuthConfig {
+  [provider: string]: ProviderConfig
+}
+
+/**
+ * Manager for social authentication providers.
+ *
+ * Lazily instantiates providers on first access and caches them.
+ * Supports all 8 built-in providers and custom providers via `extend()`.
+ *
+ * @example
+ * const manager = new SocialAuthManager(config)
+ * const github = manager.driver('github')
+ * return github.redirect()
+ */
+export class SocialAuthManager {
+  private readonly instances = new Map<string, OAuthProvider>()
+  private readonly customCreators = new Map<string, (config: ProviderConfig) => OAuthProvider>()
+
+  /** Built-in provider name → constructor mapping. */
+  private static readonly builtInProviders: Record<
+    string,
+    new (config: ProviderConfig) => OAuthProvider
+  > = {
+    google: GoogleProvider,
+    github: GitHubProvider,
+    facebook: FacebookProvider,
+    apple: AppleProvider,
+    twitter: TwitterProvider,
+    linkedin: LinkedInProvider,
+    microsoft: MicrosoftProvider,
+    discord: DiscordProvider,
+  }
+
+  constructor(private readonly config: SocialAuthConfig) {}
+
+  /**
+   * Get a provider instance by name (lazy init + cache).
+   */
+  driver(name: string): OAuthProvider {
+    if (!this.instances.has(name)) {
+      this.instances.set(name, this.createDriver(name))
+    }
+
+    return this.instances.get(name)!
+  }
+
+  /**
+   * Register a custom provider factory.
+   * Overrides built-in providers if the name matches.
+   */
+  extend(name: string, factory: (config: ProviderConfig) => OAuthProvider): void {
+    this.customCreators.set(name, factory)
+    // Clear cached instance so the new factory takes effect
+    this.instances.delete(name)
+  }
+
+  /**
+   * List all available provider names (built-in + custom + configured).
+   */
+  getProviders(): string[] {
+    const names = new Set<string>([
+      ...Object.keys(SocialAuthManager.builtInProviders),
+      ...this.customCreators.keys(),
+      ...Object.keys(this.config),
+    ])
+    return [...names]
+  }
+
+  // ── Internal ────────────────────────────────────────────────────────────
+
+  private createDriver(name: string): OAuthProvider {
+    // Custom creators take precedence — they may not need config
+    const custom = this.customCreators.get(name)
+    if (custom) {
+      const providerConfig = this.config[name] ?? {}
+      return custom(providerConfig as ProviderConfig)
+    }
+
+    const providerConfig = this.config[name]
+    if (!providerConfig) {
+      throw new Error(
+        `Social auth provider "${name}" is not configured. ` +
+          `Add it to your social-auth config file.`,
+      )
+    }
+
+    // Built-in providers
+    const ProviderClass = SocialAuthManager.builtInProviders[name]
+    if (ProviderClass) {
+      return new ProviderClass(providerConfig)
+    }
+
+    throw new Error(
+      `Unknown social auth provider "${name}". ` +
+        `Use extend() to register custom providers.`,
+    )
+  }
+}

--- a/packages/social-auth/src/SocialAuthServiceProvider.ts
+++ b/packages/social-auth/src/SocialAuthServiceProvider.ts
@@ -1,0 +1,38 @@
+import { ServiceProvider } from '@mantiq/core'
+import { SocialAuthManager } from './SocialAuthManager.ts'
+import type { SocialAuthConfig } from './SocialAuthManager.ts'
+import { setSocialAuthManager } from './helpers/social-auth.ts'
+import { ConfigRepository } from '@mantiq/core'
+
+/**
+ * Registers the SocialAuthManager in the container and sets the global helper.
+ *
+ * Reads configuration from `config/social-auth.ts` (the `social-auth` config key).
+ *
+ * @example config/social-auth.ts
+ * export default {
+ *   github: {
+ *     clientId: env('GITHUB_CLIENT_ID'),
+ *     clientSecret: env('GITHUB_CLIENT_SECRET'),
+ *     redirectUrl: env('GITHUB_REDIRECT_URL'),
+ *   },
+ *   google: {
+ *     clientId: env('GOOGLE_CLIENT_ID'),
+ *     clientSecret: env('GOOGLE_CLIENT_SECRET'),
+ *     redirectUrl: env('GOOGLE_REDIRECT_URL'),
+ *   },
+ * }
+ */
+export class SocialAuthServiceProvider extends ServiceProvider {
+  override register(): void {
+    const configRepo = this.app.make(ConfigRepository)
+    const socialConfig = configRepo.get<SocialAuthConfig>('social-auth', {})
+
+    this.app.singleton(SocialAuthManager, () => {
+      return new SocialAuthManager(socialConfig)
+    })
+
+    // Set the global helper so socialAuth() works outside the container
+    setSocialAuthManager(this.app.make(SocialAuthManager))
+  }
+}

--- a/packages/social-auth/src/contracts/OAuthProvider.ts
+++ b/packages/social-auth/src/contracts/OAuthProvider.ts
@@ -1,0 +1,11 @@
+import type { OAuthUser } from './OAuthUser.ts'
+
+export interface OAuthProvider {
+  readonly name: string
+  redirect(): Response
+  user(request: any): Promise<OAuthUser>
+  userFromToken(accessToken: string): Promise<OAuthUser>
+  scopes(scopes: string[]): this
+  with(params: Record<string, string>): this
+  stateless(): this
+}

--- a/packages/social-auth/src/contracts/OAuthUser.ts
+++ b/packages/social-auth/src/contracts/OAuthUser.ts
@@ -1,0 +1,10 @@
+export interface OAuthUser {
+  id: string
+  name: string | null
+  email: string | null
+  avatar: string | null
+  token: string
+  refreshToken: string | null
+  expiresIn: number | null
+  raw: Record<string, any>
+}

--- a/packages/social-auth/src/helpers/social-auth.ts
+++ b/packages/social-auth/src/helpers/social-auth.ts
@@ -1,0 +1,32 @@
+import type { SocialAuthManager } from '../SocialAuthManager.ts'
+
+let _manager: SocialAuthManager | null = null
+
+/**
+ * Set the global SocialAuthManager instance.
+ * Called by SocialAuthServiceProvider during registration.
+ */
+export function setSocialAuthManager(manager: SocialAuthManager): void {
+  _manager = manager
+}
+
+/**
+ * Access the global SocialAuthManager from anywhere.
+ *
+ * @example
+ * const github = socialAuth().driver('github')
+ * return github.redirect()
+ *
+ * @example
+ * const user = await socialAuth().driver('github').user(request)
+ */
+export function socialAuth(): SocialAuthManager {
+  if (!_manager) {
+    throw new Error(
+      'SocialAuthManager has not been initialized. ' +
+        'Register SocialAuthServiceProvider in your application.',
+    )
+  }
+
+  return _manager
+}

--- a/packages/social-auth/src/index.ts
+++ b/packages/social-auth/src/index.ts
@@ -1,0 +1,27 @@
+// ── Contracts ────────────────────────────────────────────────────────────────
+export type { OAuthProvider } from './contracts/OAuthProvider.ts'
+export type { OAuthUser } from './contracts/OAuthUser.ts'
+
+// ── Abstract base ────────────────────────────────────────────────────────────
+export { AbstractProvider } from './AbstractProvider.ts'
+export type { ProviderConfig } from './AbstractProvider.ts'
+
+// ── Built-in providers ───────────────────────────────────────────────────────
+export { GoogleProvider } from './providers/GoogleProvider.ts'
+export { GitHubProvider } from './providers/GitHubProvider.ts'
+export { FacebookProvider } from './providers/FacebookProvider.ts'
+export { AppleProvider } from './providers/AppleProvider.ts'
+export { TwitterProvider } from './providers/TwitterProvider.ts'
+export { LinkedInProvider } from './providers/LinkedInProvider.ts'
+export { MicrosoftProvider } from './providers/MicrosoftProvider.ts'
+export { DiscordProvider } from './providers/DiscordProvider.ts'
+
+// ── Manager ──────────────────────────────────────────────────────────────────
+export { SocialAuthManager } from './SocialAuthManager.ts'
+export type { SocialAuthConfig } from './SocialAuthManager.ts'
+
+// ── Service provider ─────────────────────────────────────────────────────────
+export { SocialAuthServiceProvider } from './SocialAuthServiceProvider.ts'
+
+// ── Global helper ────────────────────────────────────────────────────────────
+export { socialAuth, setSocialAuthManager } from './helpers/social-auth.ts'

--- a/packages/social-auth/src/providers/AppleProvider.ts
+++ b/packages/social-auth/src/providers/AppleProvider.ts
@@ -1,0 +1,144 @@
+import { AbstractProvider } from '../AbstractProvider.ts'
+import type { OAuthUser } from '../contracts/OAuthUser.ts'
+
+/**
+ * Apple Sign In provider.
+ *
+ * Apple is unique among OAuth providers:
+ * - User info is embedded in the `id_token` JWT (there is no userinfo endpoint)
+ * - The callback uses `response_mode=form_post` (POST with form data)
+ * - The user's name is only sent on the FIRST authorization; subsequent logins
+ *   only include the id_token with sub + email
+ */
+export class AppleProvider extends AbstractProvider {
+  override readonly name = 'apple'
+
+  protected override _scopes: string[] = ['name', 'email']
+  protected override _params: Record<string, string> = {
+    response_mode: 'form_post',
+  }
+
+  protected override getAuthUrl(): string {
+    return 'https://appleid.apple.com/auth/authorize'
+  }
+
+  protected override getTokenUrl(): string {
+    return 'https://appleid.apple.com/auth/token'
+  }
+
+  /**
+   * Apple does not have a userinfo endpoint. User details come from the
+   * id_token JWT returned during the token exchange. We decode the JWT
+   * payload without verification (the token was just received over TLS
+   * from Apple's server).
+   */
+  protected override async getUserByToken(token: string): Promise<Record<string, any>> {
+    // The "token" here is actually the id_token from the token response.
+    // We store the full token response in _lastTokenResponse so we can
+    // decode the id_token.
+    return this.decodeIdToken(token)
+  }
+
+  protected override mapUserToObject(raw: Record<string, any>): OAuthUser {
+    return {
+      id: String(raw.sub),
+      name: raw.name ?? null,
+      email: raw.email ?? null,
+      avatar: null, // Apple does not provide avatar URLs
+      token: '',
+      refreshToken: null,
+      expiresIn: null,
+      raw,
+    }
+  }
+
+  /**
+   * Override the user() method to extract user info from the id_token
+   * rather than calling a userinfo endpoint.
+   */
+  override async user(request: any): Promise<OAuthUser> {
+    const code = typeof request?.query === 'function'
+      ? request.query('code')
+      : this.extractCode(request)
+
+    if (!code) {
+      throw new Error('Authorization code not found in callback')
+    }
+
+    const tokenData = await this.getAccessToken(code)
+
+    // Apple returns an id_token alongside the access_token
+    const idToken = (tokenData as any).id_token
+    if (!idToken) {
+      throw new Error('Apple did not return an id_token')
+    }
+
+    const claims = this.decodeIdToken(idToken)
+
+    // On first authorization, Apple sends user info in the POST body
+    const userName = this.extractUserName(request)
+    if (userName) {
+      claims.name = userName
+    }
+
+    const oauthUser = this.mapUserToObject(claims)
+    oauthUser.token = tokenData.access_token
+    oauthUser.refreshToken = tokenData.refresh_token ?? null
+    oauthUser.expiresIn = tokenData.expires_in ?? null
+    return oauthUser
+  }
+
+  /**
+   * Decode a JWT id_token payload without signature verification.
+   * Apple's id_token contains: sub, email, email_verified, iss, aud, exp, iat.
+   */
+  private decodeIdToken(idToken: string): Record<string, any> {
+    const parts = idToken.split('.')
+    if (parts.length !== 3) {
+      throw new Error('Invalid id_token format')
+    }
+
+    const payload = parts[1]!
+    const decoded = atob(payload.replace(/-/g, '+').replace(/_/g, '/'))
+    return JSON.parse(decoded)
+  }
+
+  /**
+   * Extract the authorization code from a form_post callback.
+   */
+  private extractCode(request: any): string | null {
+    // Try URL search params first (GET)
+    try {
+      const url = new URL(request.url)
+      const code = url.searchParams.get('code')
+      if (code) return code
+    } catch {
+      // not a valid URL, ignore
+    }
+
+    // Try form body (POST with form_post response_mode)
+    if (request.body?.code) return request.body.code
+    if (request.formData?.code) return request.formData.code
+
+    return null
+  }
+
+  /**
+   * Apple sends the user's name only on first authorization, embedded in the
+   * POST body as a JSON string in the `user` field.
+   */
+  private extractUserName(request: any): string | null {
+    try {
+      const userJson = request.body?.user ?? request.formData?.user
+      if (!userJson) return null
+
+      const userData = typeof userJson === 'string' ? JSON.parse(userJson) : userJson
+      const firstName = userData.name?.firstName ?? ''
+      const lastName = userData.name?.lastName ?? ''
+      const fullName = `${firstName} ${lastName}`.trim()
+      return fullName || null
+    } catch {
+      return null
+    }
+  }
+}

--- a/packages/social-auth/src/providers/DiscordProvider.ts
+++ b/packages/social-auth/src/providers/DiscordProvider.ts
@@ -1,0 +1,51 @@
+import { AbstractProvider } from '../AbstractProvider.ts'
+import type { OAuthUser } from '../contracts/OAuthUser.ts'
+
+/**
+ * Discord OAuth 2.0 provider.
+ *
+ * Fetches user info from Discord's /users/@me endpoint.
+ * Constructs avatar URL from the user's id and avatar hash.
+ */
+export class DiscordProvider extends AbstractProvider {
+  override readonly name = 'discord'
+
+  protected override _scopes: string[] = ['identify', 'email']
+
+  protected override getAuthUrl(): string {
+    return 'https://discord.com/api/oauth2/authorize'
+  }
+
+  protected override getTokenUrl(): string {
+    return 'https://discord.com/api/oauth2/token'
+  }
+
+  protected override async getUserByToken(token: string): Promise<Record<string, any>> {
+    const res = await fetch('https://discord.com/api/users/@me', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
+    if (!res.ok) {
+      throw new Error(`Failed to fetch Discord user: ${res.status}`)
+    }
+
+    return res.json() as Promise<Record<string, any>>
+  }
+
+  protected override mapUserToObject(raw: Record<string, any>): OAuthUser {
+    const avatarUrl = raw.avatar
+      ? `https://cdn.discordapp.com/avatars/${raw.id}/${raw.avatar}.png`
+      : null
+
+    return {
+      id: String(raw.id),
+      name: raw.username ?? null,
+      email: raw.email ?? null,
+      avatar: avatarUrl,
+      token: '',
+      refreshToken: null,
+      expiresIn: null,
+      raw,
+    }
+  }
+}

--- a/packages/social-auth/src/providers/FacebookProvider.ts
+++ b/packages/social-auth/src/providers/FacebookProvider.ts
@@ -1,0 +1,47 @@
+import { AbstractProvider } from '../AbstractProvider.ts'
+import type { OAuthUser } from '../contracts/OAuthUser.ts'
+
+/**
+ * Facebook OAuth 2.0 provider.
+ *
+ * Uses the Graph API v18.0 to fetch user info.
+ */
+export class FacebookProvider extends AbstractProvider {
+  override readonly name = 'facebook'
+
+  protected override _scopes: string[] = ['email']
+
+  protected override getAuthUrl(): string {
+    return 'https://www.facebook.com/v18.0/dialog/oauth'
+  }
+
+  protected override getTokenUrl(): string {
+    return 'https://graph.facebook.com/v18.0/oauth/access_token'
+  }
+
+  protected override async getUserByToken(token: string): Promise<Record<string, any>> {
+    const url = 'https://graph.facebook.com/v18.0/me?fields=id,name,email,picture.type(large)'
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
+    if (!res.ok) {
+      throw new Error(`Failed to fetch Facebook user: ${res.status}`)
+    }
+
+    return res.json() as Promise<Record<string, any>>
+  }
+
+  protected override mapUserToObject(raw: Record<string, any>): OAuthUser {
+    return {
+      id: String(raw.id),
+      name: raw.name ?? null,
+      email: raw.email ?? null,
+      avatar: raw.picture?.data?.url ?? null,
+      token: '',
+      refreshToken: null,
+      expiresIn: null,
+      raw,
+    }
+  }
+}

--- a/packages/social-auth/src/providers/GitHubProvider.ts
+++ b/packages/social-auth/src/providers/GitHubProvider.ts
@@ -1,0 +1,80 @@
+import { AbstractProvider } from '../AbstractProvider.ts'
+import type { OAuthUser } from '../contracts/OAuthUser.ts'
+
+/**
+ * GitHub OAuth 2.0 provider.
+ *
+ * GitHub may not return the user's email in the main /user response if the
+ * email is set to private. In that case, we fetch GET /user/emails and pick
+ * the primary verified email.
+ */
+export class GitHubProvider extends AbstractProvider {
+  override readonly name = 'github'
+
+  protected override _scopes: string[] = ['user:email']
+
+  protected override getAuthUrl(): string {
+    return 'https://github.com/login/oauth/authorize'
+  }
+
+  protected override getTokenUrl(): string {
+    return 'https://github.com/login/oauth/access_token'
+  }
+
+  protected override async getUserByToken(token: string): Promise<Record<string, any>> {
+    const res = await fetch('https://api.github.com/user', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+      },
+    })
+
+    if (!res.ok) {
+      throw new Error(`Failed to fetch GitHub user: ${res.status}`)
+    }
+
+    const user = (await res.json()) as Record<string, any>
+
+    // GitHub may not include email if it's set to private — fetch from /user/emails
+    if (!user.email) {
+      user.email = await this.fetchPrimaryEmail(token)
+    }
+
+    return user
+  }
+
+  protected override mapUserToObject(raw: Record<string, any>): OAuthUser {
+    return {
+      id: String(raw.id),
+      name: raw.name ?? null,
+      email: raw.email ?? null,
+      avatar: raw.avatar_url ?? null,
+      token: '',
+      refreshToken: null,
+      expiresIn: null,
+      raw,
+    }
+  }
+
+  /**
+   * Fetch the user's primary verified email from the /user/emails endpoint.
+   */
+  private async fetchPrimaryEmail(token: string): Promise<string | null> {
+    try {
+      const res = await fetch('https://api.github.com/user/emails', {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/json',
+        },
+      })
+
+      if (!res.ok) return null
+
+      const emails = (await res.json()) as Array<{ email: string; primary: boolean; verified: boolean }>
+      const primary = emails.find((e) => e.primary && e.verified)
+      return primary?.email ?? emails[0]?.email ?? null
+    } catch {
+      return null
+    }
+  }
+}

--- a/packages/social-auth/src/providers/GoogleProvider.ts
+++ b/packages/social-auth/src/providers/GoogleProvider.ts
@@ -1,0 +1,47 @@
+import { AbstractProvider } from '../AbstractProvider.ts'
+import type { OAuthUser } from '../contracts/OAuthUser.ts'
+
+/**
+ * Google OAuth 2.0 provider.
+ *
+ * Uses the Google Identity v2 userinfo endpoint.
+ * Default scopes request OpenID Connect profile + email.
+ */
+export class GoogleProvider extends AbstractProvider {
+  override readonly name = 'google'
+
+  protected override _scopes: string[] = ['openid', 'email', 'profile']
+
+  protected override getAuthUrl(): string {
+    return 'https://accounts.google.com/o/oauth2/v2/auth'
+  }
+
+  protected override getTokenUrl(): string {
+    return 'https://oauth2.googleapis.com/token'
+  }
+
+  protected override async getUserByToken(token: string): Promise<Record<string, any>> {
+    const res = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
+    if (!res.ok) {
+      throw new Error(`Failed to fetch Google user: ${res.status}`)
+    }
+
+    return res.json() as Promise<Record<string, any>>
+  }
+
+  protected override mapUserToObject(raw: Record<string, any>): OAuthUser {
+    return {
+      id: String(raw.sub ?? raw.id),
+      name: raw.name ?? null,
+      email: raw.email ?? null,
+      avatar: raw.picture ?? null,
+      token: '',
+      refreshToken: null,
+      expiresIn: null,
+      raw,
+    }
+  }
+}

--- a/packages/social-auth/src/providers/LinkedInProvider.ts
+++ b/packages/social-auth/src/providers/LinkedInProvider.ts
@@ -1,0 +1,46 @@
+import { AbstractProvider } from '../AbstractProvider.ts'
+import type { OAuthUser } from '../contracts/OAuthUser.ts'
+
+/**
+ * LinkedIn OAuth 2.0 provider.
+ *
+ * Uses the OpenID Connect userinfo endpoint (v2 API).
+ */
+export class LinkedInProvider extends AbstractProvider {
+  override readonly name = 'linkedin'
+
+  protected override _scopes: string[] = ['openid', 'profile', 'email']
+
+  protected override getAuthUrl(): string {
+    return 'https://www.linkedin.com/oauth/v2/authorization'
+  }
+
+  protected override getTokenUrl(): string {
+    return 'https://www.linkedin.com/oauth/v2/accessToken'
+  }
+
+  protected override async getUserByToken(token: string): Promise<Record<string, any>> {
+    const res = await fetch('https://api.linkedin.com/v2/userinfo', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
+    if (!res.ok) {
+      throw new Error(`Failed to fetch LinkedIn user: ${res.status}`)
+    }
+
+    return res.json() as Promise<Record<string, any>>
+  }
+
+  protected override mapUserToObject(raw: Record<string, any>): OAuthUser {
+    return {
+      id: String(raw.sub),
+      name: raw.name ?? null,
+      email: raw.email ?? null,
+      avatar: raw.picture ?? null,
+      token: '',
+      refreshToken: null,
+      expiresIn: null,
+      raw,
+    }
+  }
+}

--- a/packages/social-auth/src/providers/MicrosoftProvider.ts
+++ b/packages/social-auth/src/providers/MicrosoftProvider.ts
@@ -1,0 +1,47 @@
+import { AbstractProvider } from '../AbstractProvider.ts'
+import type { OAuthUser } from '../contracts/OAuthUser.ts'
+
+/**
+ * Microsoft OAuth 2.0 provider.
+ *
+ * Uses the Microsoft Identity Platform (v2.0) with the /common tenant,
+ * which supports both personal Microsoft accounts and Azure AD accounts.
+ */
+export class MicrosoftProvider extends AbstractProvider {
+  override readonly name = 'microsoft'
+
+  protected override _scopes: string[] = ['openid', 'profile', 'email', 'User.Read']
+
+  protected override getAuthUrl(): string {
+    return 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize'
+  }
+
+  protected override getTokenUrl(): string {
+    return 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
+  }
+
+  protected override async getUserByToken(token: string): Promise<Record<string, any>> {
+    const res = await fetch('https://graph.microsoft.com/v1.0/me', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
+    if (!res.ok) {
+      throw new Error(`Failed to fetch Microsoft user: ${res.status}`)
+    }
+
+    return res.json() as Promise<Record<string, any>>
+  }
+
+  protected override mapUserToObject(raw: Record<string, any>): OAuthUser {
+    return {
+      id: String(raw.id),
+      name: raw.displayName ?? null,
+      email: raw.mail ?? raw.userPrincipalName ?? null,
+      avatar: null, // Microsoft Graph photo requires a separate request
+      token: '',
+      refreshToken: null,
+      expiresIn: null,
+      raw,
+    }
+  }
+}

--- a/packages/social-auth/src/providers/TwitterProvider.ts
+++ b/packages/social-auth/src/providers/TwitterProvider.ts
@@ -1,0 +1,138 @@
+import { AbstractProvider } from '../AbstractProvider.ts'
+import type { OAuthUser } from '../contracts/OAuthUser.ts'
+
+/**
+ * Twitter (X) OAuth 2.0 provider with PKCE.
+ *
+ * Twitter's OAuth 2.0 implementation requires Proof Key for Code Exchange
+ * (PKCE). This provider generates a code_verifier and code_challenge for
+ * each authorization request.
+ */
+export class TwitterProvider extends AbstractProvider {
+  override readonly name = 'twitter'
+
+  protected override _scopes: string[] = ['users.read', 'tweet.read']
+
+  /**
+   * Stored PKCE code_verifier — needed during the token exchange to prove
+   * we are the same client that initiated the authorization request.
+   */
+  private _codeVerifier: string | null = null
+
+  protected override getAuthUrl(): string {
+    return 'https://twitter.com/i/oauth2/authorize'
+  }
+
+  protected override getTokenUrl(): string {
+    return 'https://api.twitter.com/2/oauth2/token'
+  }
+
+  protected override async getUserByToken(token: string): Promise<Record<string, any>> {
+    const res = await fetch(
+      'https://api.twitter.com/2/users/me?user.fields=profile_image_url',
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    )
+
+    if (!res.ok) {
+      throw new Error(`Failed to fetch Twitter user: ${res.status}`)
+    }
+
+    return res.json() as Promise<Record<string, any>>
+  }
+
+  protected override mapUserToObject(raw: Record<string, any>): OAuthUser {
+    const data = raw.data ?? raw
+    return {
+      id: String(data.id),
+      name: data.name ?? null,
+      email: null, // Twitter does not provide email via this endpoint
+      avatar: data.profile_image_url ?? null,
+      token: '',
+      refreshToken: null,
+      expiresIn: null,
+      raw,
+    }
+  }
+
+  /**
+   * Override redirect to include PKCE parameters.
+   * Twitter requires code_challenge_method=S256.
+   */
+  override redirect(): Response {
+    this._codeVerifier = this.generateCodeVerifier()
+    const challenge = this.generateCodeChallenge(this._codeVerifier)
+
+    this.with({
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+    })
+
+    return super.redirect()
+  }
+
+  /**
+   * Override token exchange to include the code_verifier.
+   */
+  protected override async getAccessToken(
+    code: string,
+  ): Promise<{ access_token: string; refresh_token?: string; expires_in?: number }> {
+    const body: Record<string, string> = {
+      grant_type: 'authorization_code',
+      client_id: this.clientId,
+      code,
+      redirect_uri: this.redirectUrl,
+    }
+
+    if (this._codeVerifier) {
+      body.code_verifier = this._codeVerifier
+    }
+
+    const credentials = btoa(`${this.clientId}:${this.clientSecret}`)
+    const res = await fetch(this.getTokenUrl(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+        Authorization: `Basic ${credentials}`,
+      },
+      body: new URLSearchParams(body),
+    })
+
+    if (!res.ok) {
+      throw new Error(`Token exchange failed: ${res.status}`)
+    }
+
+    return res.json() as Promise<{ access_token: string; refresh_token?: string; expires_in?: number }>
+  }
+
+  /**
+   * Generate a random code_verifier for PKCE.
+   * Must be between 43 and 128 characters (RFC 7636).
+   */
+  private generateCodeVerifier(): string {
+    const bytes = new Uint8Array(32)
+    crypto.getRandomValues(bytes)
+    return this.base64UrlEncode(bytes)
+  }
+
+  /**
+   * Generate a SHA-256 code_challenge from the code_verifier.
+   */
+  private generateCodeChallenge(verifier: string): string {
+    // Use synchronous approach: hash the verifier with SHA-256
+    const encoder = new TextEncoder()
+    const data = encoder.encode(verifier)
+    const hashBuffer = new Bun.CryptoHasher('sha256').update(data).digest()
+    return this.base64UrlEncode(new Uint8Array(hashBuffer))
+  }
+
+  /**
+   * Base64url encode bytes (no padding, URL-safe).
+   */
+  private base64UrlEncode(bytes: Uint8Array): string {
+    const base64 = btoa(String.fromCharCode(...bytes))
+    return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  }
+}

--- a/packages/social-auth/tests/unit/SocialAuth.test.ts
+++ b/packages/social-auth/tests/unit/SocialAuth.test.ts
@@ -1,0 +1,156 @@
+import { describe, test, expect } from 'bun:test'
+import { AbstractProvider } from '../../src/AbstractProvider.ts'
+import { SocialAuthManager } from '../../src/SocialAuthManager.ts'
+import { GoogleProvider } from '../../src/providers/GoogleProvider.ts'
+import { GitHubProvider } from '../../src/providers/GitHubProvider.ts'
+import { FacebookProvider } from '../../src/providers/FacebookProvider.ts'
+import { AppleProvider } from '../../src/providers/AppleProvider.ts'
+import { TwitterProvider } from '../../src/providers/TwitterProvider.ts'
+import { LinkedInProvider } from '../../src/providers/LinkedInProvider.ts'
+import { MicrosoftProvider } from '../../src/providers/MicrosoftProvider.ts'
+import { DiscordProvider } from '../../src/providers/DiscordProvider.ts'
+import type { OAuthProvider } from '../../src/contracts/OAuthProvider.ts'
+import type { OAuthUser } from '../../src/contracts/OAuthUser.ts'
+
+const testConfig = {
+  clientId: 'test-client-id',
+  clientSecret: 'test-client-secret',
+  redirectUrl: 'http://localhost:3000/auth/callback',
+}
+
+// ── AbstractProvider ─────────────────────────────────────────────────────────
+
+describe('AbstractProvider', () => {
+  class TestProvider extends AbstractProvider {
+    readonly name = 'test'
+    protected override getAuthUrl() { return 'https://test.com/oauth/authorize' }
+    protected override getTokenUrl() { return 'https://test.com/oauth/token' }
+    protected override async getUserByToken(_token: string) { return { id: '1', name: 'Test' } }
+    protected override mapUserToObject(raw: any): OAuthUser {
+      return { id: raw.id, name: raw.name, email: null, avatar: null, token: '', refreshToken: null, expiresIn: null, raw }
+    }
+  }
+
+  test('redirect returns a Response with correct URL', () => {
+    const provider = new TestProvider(testConfig)
+    const response = provider.scopes(['email', 'profile']).redirect()
+    expect(response.status).toBe(302)
+    const location = response.headers.get('location') ?? ''
+    expect(location).toContain('https://test.com/oauth/authorize')
+    expect(location).toContain('client_id=test-client-id')
+    expect(location).toContain('redirect_uri=')
+    expect(location).toContain('response_type=code')
+  })
+
+  test('scopes() sets requested scopes', () => {
+    const provider = new TestProvider(testConfig)
+    provider.scopes(['email', 'profile'])
+    const location = provider.redirect().headers.get('location') ?? ''
+    expect(location).toContain('scope=email+profile')
+  })
+
+  test('with() adds extra params', () => {
+    const provider = new TestProvider(testConfig)
+    provider.with({ prompt: 'consent' })
+    const location = provider.redirect().headers.get('location') ?? ''
+    expect(location).toContain('prompt=consent')
+  })
+
+  test('stateless() disables state', () => {
+    const provider = new TestProvider(testConfig)
+    provider.stateless()
+    const location = provider.redirect().headers.get('location') ?? ''
+    expect(location).not.toContain('state=')
+  })
+
+  test('userFromToken resolves user', async () => {
+    const provider = new TestProvider(testConfig)
+    const user = await provider.userFromToken('fake-token')
+    expect(user.id).toBe('1')
+    expect(user.name).toBe('Test')
+    expect(user.token).toBe('fake-token')
+  })
+})
+
+// ── SocialAuthManager ────────────────────────────────────────────────────────
+
+describe('SocialAuthManager', () => {
+  test('driver returns a provider instance', () => {
+    const manager = new SocialAuthManager({
+      google: testConfig,
+    })
+    const provider = manager.driver('google')
+    expect(provider.name).toBe('google')
+  })
+
+  test('driver throws for unknown provider', () => {
+    const manager = new SocialAuthManager({})
+    expect(() => manager.driver('unknown')).toThrow()
+  })
+
+  test('extend registers custom provider', () => {
+    const manager = new SocialAuthManager({})
+
+    class CustomProvider extends AbstractProvider {
+      readonly name = 'custom'
+      protected override getAuthUrl() { return 'https://custom.com/auth' }
+      protected override getTokenUrl() { return 'https://custom.com/token' }
+      protected override async getUserByToken() { return {} }
+      protected override mapUserToObject(raw: any): OAuthUser {
+        return { id: '1', name: null, email: null, avatar: null, token: '', refreshToken: null, expiresIn: null, raw }
+      }
+    }
+
+    manager.extend('custom', () => new CustomProvider(testConfig))
+    const provider = manager.driver('custom')
+    expect(provider.name).toBe('custom')
+  })
+
+  test('getProviders lists registered names', () => {
+    const manager = new SocialAuthManager({
+      google: testConfig,
+      github: testConfig,
+    })
+    const names = manager.getProviders()
+    expect(names).toContain('google')
+    expect(names).toContain('github')
+  })
+
+  test('driver caches instances', () => {
+    const manager = new SocialAuthManager({ google: testConfig })
+    const a = manager.driver('google')
+    const b = manager.driver('google')
+    expect(a).toBe(b)
+  })
+})
+
+// ── Built-in Providers (redirect URL construction) ───────────────────────────
+
+describe('Built-in Providers', () => {
+  const providers: [string, new (config: any) => OAuthProvider][] = [
+    ['google', GoogleProvider],
+    ['github', GitHubProvider],
+    ['facebook', FacebookProvider],
+    ['apple', AppleProvider],
+    ['twitter', TwitterProvider],
+    ['linkedin', LinkedInProvider],
+    ['microsoft', MicrosoftProvider],
+    ['discord', DiscordProvider],
+  ]
+
+  for (const [name, Provider] of providers) {
+    test(`${name} — redirect returns 302 with valid URL`, () => {
+      const provider = new Provider(testConfig)
+      const response = provider.redirect()
+      expect(response.status).toBe(302)
+      const location = response.headers.get('location') ?? ''
+      expect(location).toContain('client_id=test-client-id')
+      expect(location).toContain('response_type=code')
+    })
+
+    test(`${name} — name property is correct`, () => {
+      const provider = new Provider(testConfig)
+      expect(provider.name).toBe(name)
+    })
+  }
+})

--- a/packages/social-auth/tsconfig.json
+++ b/packages/social-auth/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "./dist", "rootDir": "./src" },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Two new packages for OAuth 2.0:

### @mantiq/oauth — Server (34 files)
Full OAuth 2.0 server with zero external dependencies (JWT via Web Crypto API).

- **JWT**: RS256 sign/verify/keygen using `crypto.subtle`
- **Grants**: Authorization Code (PKCE mandatory), Client Credentials, Refresh Token, Personal Access
- **Models**: Client, AccessToken, AuthCode, RefreshToken (UUID PKs)
- **Guard**: JwtGuard for stateless Bearer auth
- **Routes**: `/oauth/token`, `/oauth/authorize`, `/oauth/clients`, `/oauth/scopes`
- **Middleware**: CheckScopes, CheckForAnyScope, CheckClientCredentials
- **CLI**: `oauth:install`, `oauth:keys`, `oauth:client`, `oauth:purge`

### @mantiq/social-auth — Client (15 files)
Social login with extensible provider contract.

- **8 providers**: Google, GitHub, Facebook, Apple, Twitter, LinkedIn, Microsoft, Discord
- **Contract**: `OAuthProvider` interface — extend for any custom provider
- **AbstractProvider**: base class handles OAuth 2.0 auth code flow
- **Manager**: `socialAuth().driver('google').redirect()`

## Test plan

- [x] 9 JWT tests (sign, verify, expired, tampered, key mismatch)
- [x] 26 social-auth tests (providers, manager, redirect URLs, custom providers)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)