### PR TITLE
feat(skeleton): unified dev command

### DIFF
--- a/packages/create-mantiq/src/templates.ts
+++ b/packages/create-mantiq/src/templates.ts
@@ -798,7 +798,9 @@ function applyKitOverrides(templates: Record<string, string>, ctx: TemplateConte
     private: true,
     type: 'module',
     scripts: {
-      dev: 'bun run --watch index.ts',
+      dev: 'bun run dev:backend & bun run dev:frontend & wait',
+      'dev:backend': 'bun run --watch index.ts',
+      'dev:frontend': 'bunx vite --clearScreen false',
       start: 'bun run index.ts',
       mantiq: 'bun run mantiq.ts',
       build: `vite build && vite build --ssr ${kit === 'react' ? 'src/ssr.tsx' : 'src/ssr.ts'} --outDir bootstrap/ssr`,


### PR DESCRIPTION
## Summary

`bun run dev` now starts both backend and Vite HMR in one terminal for kit-based apps.

Before: Two terminals needed
- Terminal 1: `bun run dev` (backend only)
- Terminal 2: `npx vite` (frontend HMR)

After: One command
- `bun run dev` (both concurrently)
- `bun run dev:backend` (backend only, if needed)
- `bun run dev:frontend` (vite only, if needed)

API-only apps unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)