### PR TITLE
release: 0.5.21 — @mantiq/testing, 65 DB tests, MSSQL driver fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mantiqjs",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "type": "module",
   "private": true,
   "workspaces": [

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/auth",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Session & token auth, guards, providers",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/cli",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Command runner, code generators, dev server",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/core",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Service container, router, middleware, HTTP kernel, config, and exception handler",
   "type": "module",
   "license": "MIT",

--- a/packages/create-mantiq/package.json
+++ b/packages/create-mantiq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mantiq",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Scaffold a new MantiqJS application",
   "type": "module",
   "license": "MIT",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/database",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Query builder, ORM, migrations, seeders, factories — with SQLite, Postgres, MySQL and MongoDB support",
   "type": "module",
   "license": "MIT",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/events",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Event dispatcher, listeners, observers, and broadcasting for MantiqJS",
   "type": "module",
   "license": "MIT",

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/filesystem",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Filesystem abstraction — local, S3, GCS, R2, Azure, FTP, SFTP drivers with uniform API",
   "type": "module",
   "license": "MIT",

--- a/packages/health/package.json
+++ b/packages/health/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/health",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Application health checks — database, cache, queue, filesystem, mail, and custom checks",
   "type": "module",
   "license": "MIT",

--- a/packages/heartbeat/package.json
+++ b/packages/heartbeat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/heartbeat",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Observability, APM & queue monitoring for MantiqJS",
   "type": "module",
   "license": "MIT",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/helpers",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Str, Arr, Num, Collection utilities",
   "type": "module",
   "license": "MIT",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/logging",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Channel-based logging",
   "type": "module",
   "license": "MIT",

--- a/packages/mail/package.json
+++ b/packages/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/mail",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Transactional email — SMTP, Resend, SendGrid, Mailgun, Postmark, SES, markdown templates",
   "type": "module",
   "license": "MIT",

--- a/packages/notify/package.json
+++ b/packages/notify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/notify",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Multi-channel notifications — mail, database, broadcast, SMS, Slack, webhook",
   "type": "module",
   "license": "MIT",

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/oauth",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "OAuth 2.0 server — authorization code (PKCE), client credentials, JWT access tokens, scopes",
   "type": "module",
   "license": "MIT",

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/queue",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Job dispatching, workers, retry logic",
   "type": "module",
   "license": "MIT",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/realtime",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "WebSocket, SSE, channels, broadcasting",
   "type": "module",
   "license": "MIT",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/search",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Full-text search abstraction — Algolia, Meilisearch, Typesense, Elasticsearch, database, and collection drivers",
   "type": "module",
   "license": "MIT",

--- a/packages/social-auth/package.json
+++ b/packages/social-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/social-auth",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Social authentication — login with Google, GitHub, Facebook, Apple, and more via extensible providers",
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/testing",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Testing utilities for MantiqJS — HTTP client, database assertions, auth helpers",
   "type": "module",
   "license": "MIT",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/validation",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Rule engine, form requests",
   "type": "module",
   "license": "MIT",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/vite",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Vite dev server & manifest integration",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- @mantiq/testing package (21st) — 31 unit tests, 45 assertion methods
- 65 new database connection tests (connections + config variations)
- MSSQL added to SQLConfig driver union + DatabaseManager switch
- Example tests in all scaffolded apps (auth, CRUD, token-auth)
- Database config with all driver options + read/write replicas + MariaDB
- config/vite.ts for React Refresh + SSR
- Type safety: 18→0 as-any in stubs, FormRequest auto-validation

## CI

- 11/11 jobs pass (typecheck, build, test, 4 e2e, 4 sanity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)