### PR TITLE
fix: realtime integration — channel auth, WS cookies, SSR HMR, formData

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Mantiq is a full-stack TypeScript web framework for Bun (>=1.1.0). It follows Laravel-inspired conventions with a modular monorepo of 23 packages under `@mantiq/*`. All packages use ESM (`"type": "module"`) with TypeScript strict mode.
+
+## Common Commands
+
+```bash
+# Development
+bun install                          # Install all workspace deps
+bun run dev                          # Start dev server
+bun mantiq key:generate              # Generate encryption key
+
+# Testing
+bun run test                         # Run all unit tests
+bun test packages/core/              # Run tests for a single package
+bun run test:ci                      # CI variant (needs service containers)
+bunx playwright test                 # E2E browser tests
+bunx playwright test e2e/auth-flow.spec.ts  # Single E2E test
+
+# Quality
+bun run typecheck                    # TypeScript strict validation across all packages
+bun run lint                         # Lint all packages
+bun run build                        # Build all packages
+
+# Database
+bun mantiq migrate                   # Run migrations
+bun mantiq seed                      # Seed database
+bun mantiq schema:generate           # Generate TypeScript interfaces from DB schema
+
+# Code generation
+bun mantiq make:model Post --migration
+bun mantiq make:controller PostController
+bun mantiq make:middleware AuthMiddleware
+```
+
+## Architecture
+
+### Monorepo Structure
+
+Workspace root manages all packages. Internal deps use `workspace:*` protocol. Path aliases in `tsconfig.json` map `@mantiq/*` to `packages/*/src/index.ts`.
+
+### Key Packages
+
+- **core** — IoC container, router, middleware pipeline, HTTP kernel, config, encryption, hashing, cache, sessions
+- **database** — Query builder, Eloquent-style ORM, migrations, seeders, factories (SQLite, Postgres, MySQL, MSSQL, MongoDB)
+- **auth** — Session & token guards, user providers, authentication middleware
+- **cli** — 40 generator/utility commands, command kernel, dev server
+- **validation** — Rule engine (`required|email|min:8`), 40+ rules, FormRequest
+- **helpers** — Str, Arr, Num, Collection classes, HTTP client, async utilities
+- **create-mantiq** — Project scaffolder (`bun create mantiq`)
+
+### Core Patterns
+
+**Service Container**: IoC with `bind()`, `singleton()`, `transient()`. Constructor injection with auto-resolution. Service providers register via `boot()` and `register()` lifecycle methods. Auto-discovered via `"mantiq.provider"` in package.json.
+
+**Routing**: Express-like syntax with parameter constraints (`whereNumber()`, `whereAlpha()`), route groups, resource routing, middleware grouping.
+
+**Middleware Pipeline**: Stack-based `Pipeline` class. Built-in: `StartSession`, `VerifyCsrfToken`, `EncryptCookies`, `CorsMiddleware`, `TrimStringsMiddleware`.
+
+**ORM**: Models with fillable, hidden, casts. Relations, eager loading, pagination, factories, observers.
+
+**Validation**: `FormRequest` auto-validates before controller. Rule strings or custom rule classes.
+
+### Testing
+
+Tests use Bun's native test runner (`bun:test`) with `describe`/`it`/`expect`. Tests live in `packages/*/tests/` split into `unit/` and `integration/` directories. E2E tests use Playwright in `e2e/`.
+
+### CI Pipeline
+
+GitHub Actions runs: test (with Postgres, MySQL, MSSQL, Redis, Meilisearch, Elasticsearch, Typesense), typecheck, build, scaffold verification, and E2E (Playwright) jobs.
+
+### Publishing
+
+Manual workflow via `.github/workflows/publish.yml`. Supports dry-run and individual package selection. Uses `bun run version:set X.Y.Z` for version sync across all packages.

--- a/packages/core/src/contracts/Request.ts
+++ b/packages/core/src/contracts/Request.ts
@@ -50,6 +50,9 @@ export interface MantiqRequest {
   isAuthenticated(): boolean
   setUser(user: any): void
 
+  // ── FormData ────────────────────────────────────────────────────────────
+  formData(): Promise<FormData>
+
   // ── Raw ──────────────────────────────────────────────────────────────────
   raw(): Request
 }

--- a/packages/core/src/http/Request.ts
+++ b/packages/core/src/http/Request.ts
@@ -213,6 +213,12 @@ export class MantiqRequest implements MantiqRequestContract {
     this.authenticatedUser = user
   }
 
+  // ── FormData ────────────────────────────────────────────────────────────
+
+  async formData(): Promise<FormData> {
+    return this.bunRequest.clone().formData()
+  }
+
   // ── Raw ──────────────────────────────────────────────────────────────────
 
   raw(): Request {

--- a/packages/core/src/providers/CoreServiceProvider.ts
+++ b/packages/core/src/providers/CoreServiceProvider.ts
@@ -98,6 +98,10 @@ export class CoreServiceProvider extends ServiceProvider {
     if (appKey) {
       const encrypter = await AesEncrypter.fromAppKey(appKey)
       this.app.instance(ENCRYPTER, encrypter)
+
+      // Give WebSocketKernel the encrypter so it can decrypt cookies on upgrade
+      const wsKernel = this.app.make(WebSocketKernel)
+      wsKernel.setEncrypter(encrypter)
     }
 
     // ── Auto-register middleware aliases on HttpKernel ─────────────────────

--- a/packages/core/src/websocket/WebSocketKernel.ts
+++ b/packages/core/src/websocket/WebSocketKernel.ts
@@ -1,5 +1,7 @@
 import type { WebSocketHandler } from './WebSocketContext.ts'
+import type { AesEncrypter } from '../encryption/Encrypter.ts'
 import { MantiqRequest } from '../http/Request.ts'
+import { parseCookies } from '../http/Cookie.ts'
 
 /**
  * Handles WebSocket upgrade detection and lifecycle delegation.
@@ -9,12 +11,21 @@ import { MantiqRequest } from '../http/Request.ts'
  */
 export class WebSocketKernel {
   private handler: WebSocketHandler | null = null
+  private encrypter: AesEncrypter | null = null
 
   /**
    * Called by @mantiq/realtime to register its WebSocket handler.
    */
   registerHandler(handler: WebSocketHandler): void {
     this.handler = handler
+  }
+
+  /**
+   * Inject the encrypter so WebSocket upgrades can decrypt cookies.
+   * Called during CoreServiceProvider boot.
+   */
+  setEncrypter(encrypter: AesEncrypter): void {
+    this.encrypter = encrypter
   }
 
   /**
@@ -29,6 +40,13 @@ export class WebSocketKernel {
     }
 
     const mantiqRequest = MantiqRequest.fromBun(request)
+
+    // Decrypt cookies — WebSocket upgrades bypass the middleware pipeline,
+    // so EncryptCookies never runs. Manually decrypt here.
+    if (this.encrypter) {
+      await this.decryptCookies(mantiqRequest)
+    }
+
     const context = await this.handler.onUpgrade(mantiqRequest)
 
     if (!context) {
@@ -56,5 +74,30 @@ export class WebSocketKernel {
       close: (ws: any, code: number, reason: string) => h?.close(ws, code, reason),
       drain: (ws: any) => h?.drain(ws),
     }
+  }
+
+  // ── Private ───────────────────────────────────────────────────────────────
+
+  private async decryptCookies(request: MantiqRequest): Promise<void> {
+    const cookieHeader = request.header('cookie')
+    if (!cookieHeader) return
+
+    const cookies = parseCookies(cookieHeader)
+    const decrypted: Record<string, string> = {}
+    const except = ['XSRF-TOKEN']
+
+    for (const [name, value] of Object.entries(cookies)) {
+      if (except.includes(name)) {
+        decrypted[name] = value
+        continue
+      }
+      try {
+        decrypted[name] = await this.encrypter!.decrypt(value)
+      } catch {
+        decrypted[name] = value
+      }
+    }
+
+    request.setCookies(decrypted)
   }
 }

--- a/packages/realtime/src/channels/ChannelManager.ts
+++ b/packages/realtime/src/channels/ChannelManager.ts
@@ -35,7 +35,9 @@ export class ChannelManager {
    * The pattern is matched against the base name (without the prefix).
    */
   authorize(pattern: string, callback: ChannelAuthorizer): void {
-    this.authorizers.set(pattern, callback)
+    // Strip channel-type prefix so the pattern matches against baseName
+    const { baseName } = parseChannelName(pattern)
+    this.authorizers.set(baseName, callback)
   }
 
   // ── Subscribe / Unsubscribe ─────────────────────────────────────────────

--- a/packages/vite/src/Vite.ts
+++ b/packages/vite/src/Vite.ts
@@ -17,7 +17,6 @@ export class Vite {
   // ── SSR state ───────────────────────────────────────────────────────────
   private readonly ssrEntry: string | null
   private readonly ssrBundle: string
-  private viteDevServer: any | null = null
   private ssrModuleCache: SSRModule | null = null
   /** Application base path (for resolving SSR bundle). Set via setBasePath(). */
   private basePath: string = ''
@@ -316,24 +315,12 @@ export class Vite {
   }
 
   /**
-   * Get or lazily create the embedded Vite dev server (for SSR module loading).
-   * Only used in development mode with SSR enabled.
-   */
-  private async getViteDevServer(): Promise<any> {
-    if (this.viteDevServer) return this.viteDevServer
-
-    const { createServer } = await import('vite')
-    this.viteDevServer = await createServer({
-      server: { middlewareMode: true },
-      appType: 'custom',
-    })
-
-    return this.viteDevServer
-  }
-
-  /**
-   * Load the SSR module. In dev mode, uses Vite's ssrLoadModule for HMR.
-   * In production, imports the pre-built bundle.
+   * Load the SSR module.
+   *
+   * In dev mode: uses Bun's native import (handles TSX, path aliases via tsconfig).
+   * No embedded Vite server needed — avoids HMR conflicts with the standalone dev server.
+   *
+   * In production: imports the pre-built SSR bundle.
    */
   private async loadSSRModule(): Promise<SSRModule> {
     if (this.ssrModuleCache) return this.ssrModuleCache
@@ -345,9 +332,11 @@ export class Vite {
     let mod: any
 
     if (this.isDev()) {
-      // Dev: use Vite's ssrLoadModule for HMR + transform
-      const server = await this.getViteDevServer()
-      mod = await server.ssrLoadModule(this.ssrEntry)
+      // Dev: use Bun's native import — it handles TSX and tsconfig path aliases
+      const entryPath = this.basePath
+        ? `${this.basePath}/${this.ssrEntry}`
+        : this.ssrEntry
+      mod = await import(entryPath)
     } else {
       // Prod: import the pre-built SSR bundle
       const bundlePath = this.basePath
@@ -383,24 +372,7 @@ export class Vite {
    */
   private async renderSSR(url: string, data?: Record<string, unknown>): Promise<SSRResult> {
     const ssrModule = await this.loadSSRModule()
-
-    try {
-      return await ssrModule.render(url, data)
-    } catch (err) {
-      // In dev, fix the stack trace for better DX
-      if (this.isDev() && this.viteDevServer && err instanceof Error) {
-        this.viteDevServer.ssrFixStacktrace(err)
-      }
-      throw err
-    }
-  }
-
-  /** Close the embedded Vite dev server (cleanup). */
-  async closeDevServer(): Promise<void> {
-    if (this.viteDevServer) {
-      await this.viteDevServer.close()
-      this.viteDevServer = null
-    }
+    return await ssrModule.render(url, data)
   }
 
   // ── HTML Shell ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Channel auth mismatch** — `ChannelManager.authorize()` stored patterns with prefixes (`presence:`, `private:`) but `findAuthorizer()` searched by baseName (stripped). Authorizers never matched → all private/presence subscriptions failed silently.
- **WebSocket cookie decryption** — WS upgrades bypass middleware, so `EncryptCookies` never ran. Session cookie arrived encrypted → auth always returned 401. `WebSocketKernel` now decrypts cookies before calling `onUpgrade()`.
- **SSR embedded Vite server HMR conflicts** — The embedded Vite dev server for SSR loaded the project's full `vite.config.ts`, wrote to `node_modules/.vite/`, caused `bun --watch` restart loops and cross-tab full-reloads. Replaced with Bun's native `import()` which handles TSX and tsconfig path aliases without any embedded server.
- **Missing `formData()` on MantiqRequest** — Controllers calling `request.formData()` got a runtime error. Added as a proxy to the underlying Bun Request.

## Test plan

- [x] `bun test packages/core/` — 419 pass
- [x] `bun test packages/realtime/` — 129 pass
- [ ] Manual: open chat app in two browsers, verify WS connects, messages broadcast, no cross-tab reloads
- [ ] Manual: upload a file in chat, verify `formData()` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)