### PR TITLE
fix: sanitizeColumn MSSQL compat + schema:generate all SQL dialects

### DIFF
--- a/packages/database/src/query/Builder.ts
+++ b/packages/database/src/query/Builder.ts
@@ -455,14 +455,13 @@ applyMacros(QueryBuilder)
  */
 function sanitizeColumn(column: string): string {
   // Already quoted — pass through
-  if (column.startsWith('"') || column.startsWith('`') || column.startsWith("'")) return column
+  if (column.startsWith('"') || column.startsWith('`') || column.startsWith("'") || column.startsWith('[')) return column
 
   // Validate: only allow alphanumeric, underscores, dots
   if (!/^[\w]+(?:\.[\w]+)?$/.test(column)) {
     throw new Error(`Invalid column name: "${column}"`)
   }
-  // Quote the column: users.created_at → "users"."created_at"
-  return column.split('.').map(part => `"${part}"`).join('.')
+  return column
 }
 
 const VALID_OPERATORS = new Set(['=', '!=', '<>', '<', '>', '<=', '>=', 'LIKE', 'NOT LIKE', 'IN', 'NOT IN', 'IS', 'IS NOT', 'BETWEEN'])

--- a/packages/database/tests/unit/query-features.test.ts
+++ b/packages/database/tests/unit/query-features.test.ts
@@ -106,19 +106,19 @@ describe('Date where clauses', () => {
   test('whereDate generates DATE() SQL', () => {
     const conn = makeConn()
     const sql = conn.table('posts').whereDate('created_at', '2024-01-15').toSql()
-    expect(sql).toContain('DATE("created_at") = ?')
+    expect(sql).toContain('DATE(created_at) = ?')
   })
 
   test('whereDate with operator', () => {
     const conn = makeConn()
     const sql = conn.table('posts').whereDate('created_at', '>=', '2024-01-01').toSql()
-    expect(sql).toContain('DATE("created_at") >= ?')
+    expect(sql).toContain('DATE(created_at) >= ?')
   })
 
   test('whereMonth generates strftime SQL', () => {
     const conn = makeConn()
     const sql = conn.table('posts').whereMonth('created_at', 3).toSql()
-    expect(sql).toContain('strftime(\'%m\', "created_at") = ?')
+    expect(sql).toContain("strftime('%m', created_at) = ?")
   })
 
   test('whereMonth pads single digit months', () => {
@@ -130,19 +130,19 @@ describe('Date where clauses', () => {
   test('whereYear generates strftime SQL', () => {
     const conn = makeConn()
     const sql = conn.table('posts').whereYear('created_at', 2024).toSql()
-    expect(sql).toContain('strftime(\'%Y\', "created_at") = ?')
+    expect(sql).toContain("strftime('%Y', created_at) = ?")
   })
 
   test('whereYear with operator', () => {
     const conn = makeConn()
     const sql = conn.table('posts').whereYear('created_at', '>=', 2020).toSql()
-    expect(sql).toContain('strftime(\'%Y\', "created_at") >= ?')
+    expect(sql).toContain("strftime('%Y', created_at) >= ?")
   })
 
   test('whereTime generates strftime SQL', () => {
     const conn = makeConn()
     const sql = conn.table('events').whereTime('starts_at', '>=', '10:00').toSql()
-    expect(sql).toContain('strftime(\'%H:%M:%S\', "starts_at") >= ?')
+    expect(sql).toContain("strftime('%H:%M:%S', starts_at) >= ?")
   })
 })
 


### PR DESCRIPTION
## Summary

- sanitizeColumn() validates without quoting — grammar handles dialect-specific quoting
- schema:generate expanded to 80+ SQL types (Postgres, MySQL, MSSQL)
- PK columns correctly non-nullable
- Fixes MSSQL join test failures

## CI must pass before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)