### PR TITLE
security: XSS links, header injection, OAuth isolation, CSP nonce, error page

### DIFF
--- a/packages/core/src/exceptions/DevErrorPage.ts
+++ b/packages/core/src/exceptions/DevErrorPage.ts
@@ -10,6 +10,21 @@ import type { MantiqRequest } from '../contracts/Request.ts'
  * - Copy as Markdown button
  * - Source file context when available
  */
+/**
+ * Security: headers that must never appear on the debug page, even in dev mode.
+ * These can contain authentication credentials, session tokens, and CSRF secrets.
+ */
+const SENSITIVE_HEADERS = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-csrf-token',
+  'x-xsrf-token',
+  'proxy-authorization',
+  'x-api-key',
+  'x-auth-token',
+])
+
 export function renderDevErrorPage(request: MantiqRequest, error: unknown): string {
   const err = error instanceof Error ? error : new Error(String(error))
   const stack = err.stack ?? err.message
@@ -51,8 +66,13 @@ export function renderDevErrorPage(request: MantiqRequest, error: unknown): stri
     })
     .join('')
 
+  // Security: redact sensitive headers to prevent leaking auth tokens,
+  // cookies, and CSRF secrets — even on the dev error page.
   const headersHtml = Object.entries(request.headers())
-    .map(([k, v]) => `<tr><td class="td-key">${escapeHtml(k)}</td><td class="td-val">${escapeHtml(v)}</td></tr>`)
+    .map(([k, v]) => {
+      const redacted = SENSITIVE_HEADERS.has(k.toLowerCase()) ? '********' : v
+      return `<tr><td class="td-key">${escapeHtml(k)}</td><td class="td-val">${escapeHtml(redacted)}</td></tr>`
+    })
     .join('')
 
   const queryString = request.fullUrl().includes('?') ? request.fullUrl().split('?')[1] : ''
@@ -63,14 +83,13 @@ export function renderDevErrorPage(request: MantiqRequest, error: unknown): stri
     }).join('')
     : '<tr><td class="td-val" colspan="2" style="opacity:.5">No query parameters</td></tr>'
 
-  // Markdown for clipboard
+  // Markdown for clipboard — also redact sensitive headers
   const markdown = [
     `# ${err.name}: ${err.message}`,
     '',
     `**Status:** ${statusCode}`,
     `**Method:** ${request.method()}`,
     `**URL:** ${request.fullUrl()}`,
-    `**IP:** ${request.ip()}`,
     `**User Agent:** ${request.userAgent()}`,
     '',
     '## Stack Trace',
@@ -81,7 +100,10 @@ export function renderDevErrorPage(request: MantiqRequest, error: unknown): stri
     '## Request Headers',
     '| Header | Value |',
     '|--------|-------|',
-    ...Object.entries(request.headers()).map(([k, v]) => `| ${k} | ${v} |`),
+    ...Object.entries(request.headers()).map(([k, v]) => {
+      const redacted = SENSITIVE_HEADERS.has(k.toLowerCase()) ? '********' : v
+      return `| ${k} | ${redacted} |`
+    }),
     '',
     `*Bun ${bunVersion} — MantiqJS*`,
   ].join('\n')
@@ -454,7 +476,7 @@ export function renderDevErrorPage(request: MantiqRequest, error: unknown): stri
             <tr><td class="td-key">Method</td><td class="td-val">${escapeHtml(request.method())}</td></tr>
             <tr><td class="td-key">Path</td><td class="td-val">${escapeHtml(request.path())}</td></tr>
             <tr><td class="td-key">Full URL</td><td class="td-val">${escapeHtml(request.fullUrl())}</td></tr>
-            <tr><td class="td-key">IP Address</td><td class="td-val">${escapeHtml(request.ip())}</td></tr>
+            <!-- Security: IP address omitted to prevent leaking client addresses in shared debug output -->
             <tr><td class="td-key">User Agent</td><td class="td-val">${escapeHtml(request.userAgent())}</td></tr>
             <tr><td class="td-key">Expects JSON</td><td class="td-val">${request.expectsJson() ? 'Yes' : 'No'}</td></tr>
             <tr><td class="td-key">Authenticated</td><td class="td-val">${request.isAuthenticated() ? 'Yes' : 'No'}</td></tr>

--- a/packages/core/src/exceptions/Handler.ts
+++ b/packages/core/src/exceptions/Handler.ts
@@ -85,6 +85,7 @@ export class DefaultExceptionHandler implements ExceptionHandler {
   ): Response {
     // API routes always get JSON — even in debug mode
     if (request.expectsJson()) {
+      // Security: in production (debug=false), never expose error details
       const body: Record<string, any> = { error: { message: 'Internal Server Error', status: 500 } }
       if (debug && err.stack) {
         body['error']['message'] = err.message

--- a/packages/core/src/http/Response.ts
+++ b/packages/core/src/http/Response.ts
@@ -66,15 +66,37 @@ export class MantiqResponse {
     return new Response(stream)
   }
 
+  /**
+   * Security: sanitize Content-Disposition filename to prevent header injection.
+   * - Strip CR/LF to block header injection via newlines
+   * - Escape double quotes to prevent breaking out of the quoted filename
+   * - Strip path separators to prevent directory traversal
+   * - Use RFC 6266 filename* parameter for non-ASCII characters
+   */
+  private static sanitizeFilename(filename: string): string {
+    return filename
+      .replace(/[\r\n]/g, '')       // Strip newlines — prevents header injection
+      .replace(/[/\\]/g, '')        // Strip path separators — prevents traversal
+      .replace(/"/g, '\\"')         // Escape quotes — prevents breaking out of quoted string
+  }
+
   static download(
     content: Uint8Array | string,
     filename: string,
     mimeType?: string,
   ): Response {
+    const sanitized = MantiqResponse.sanitizeFilename(filename)
+
+    // RFC 6266: use filename* with UTF-8 encoding for non-ASCII filenames
+    const isAscii = /^[\x20-\x7E]+$/.test(sanitized)
+    const disposition = isAscii
+      ? `attachment; filename="${sanitized}"`
+      : `attachment; filename="${sanitized}"; filename*=UTF-8''${encodeURIComponent(sanitized)}`
+
     return new Response(content, {
       headers: {
         'Content-Type': mimeType ?? 'application/octet-stream',
-        'Content-Disposition': `attachment; filename="${filename}"`,
+        'Content-Disposition': disposition,
       },
     })
   }

--- a/packages/core/src/middleware/SecureHeaders.ts
+++ b/packages/core/src/middleware/SecureHeaders.ts
@@ -39,10 +39,18 @@ export class SecureHeaders implements Middleware {
       }
     }
 
-    // Control what the browser is allowed to load
+    // Control what the browser is allowed to load.
+    // Security: do NOT include 'unsafe-inline' or 'unsafe-eval' — they defeat
+    // the purpose of CSP. Use nonce-based script/style loading instead.
+    // The nonce is generated per-request; pass it to templates via request.cspNonce.
     if (!headers.has('Content-Security-Policy')) {
-      // Permissive default — users should tighten in production
-      headers.set('Content-Security-Policy', "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:")
+      const nonce = crypto.randomUUID().replace(/-/g, '')
+      // Attach nonce to request so templates/views can reference it
+      ;(request as any).cspNonce = nonce
+      headers.set(
+        'Content-Security-Policy',
+        `default-src 'self'; script-src 'self' 'nonce-${nonce}'; style-src 'self' 'nonce-${nonce}'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'`,
+      )
     }
 
     // Prevent leaking referer to external sites

--- a/packages/mail/src/markdown/MarkdownRenderer.ts
+++ b/packages/mail/src/markdown/MarkdownRenderer.ts
@@ -34,7 +34,14 @@ function markdownToHtml(md: string): string {
     const buttonMatch = trimmed.match(/^\[button\s+url="([^"]+)"\](.*?)\[\/button\]$/)
     if (buttonMatch) {
       if (inList) { html += `</${inList}>`; inList = null }
-      html += renderButton(buttonMatch[1]!, buttonMatch[2]!)
+      // Security: sanitize button URL to block javascript:/data:/vbscript: schemes
+      const safeButtonUrl = sanitizeLinkUrl(buttonMatch[1]!)
+      if (safeButtonUrl) {
+        html += renderButton(safeButtonUrl, buttonMatch[2]!)
+      } else {
+        // Dangerous scheme — render as plain text, not a clickable button
+        html += `<p class="email-text" style="margin:12px 0;line-height:1.65;color:#1a1a1a;">${inlineFormatting(buttonMatch[2]!)}</p>`
+      }
       i++
       continue
     }
@@ -122,6 +129,25 @@ function markdownToHtml(md: string): string {
   return html
 }
 
+/**
+ * Security: strip links with dangerous URI schemes (javascript:, data:, vbscript:)
+ * to prevent XSS in rendered email HTML. Only http:, https:, mailto:, and
+ * relative URLs are allowed.
+ */
+function sanitizeLinkUrl(url: string): string | null {
+  const trimmed = url.trim()
+  // Reject dangerous schemes — case-insensitive, ignoring leading whitespace
+  const lower = trimmed.toLowerCase()
+  if (
+    lower.startsWith('javascript:') ||
+    lower.startsWith('data:') ||
+    lower.startsWith('vbscript:')
+  ) {
+    return null
+  }
+  return trimmed
+}
+
 /** Process inline markdown: bold, italic, code, links */
 function inlineFormatting(text: string): string {
   return text
@@ -131,6 +157,13 @@ function inlineFormatting(text: string): string {
     .replace(/\*(.+?)\*/g, '<em>$1</em>')
     // Inline code
     .replace(/`([^`]+)`/g, '<code class="email-code" style="background:#f3f4f6;padding:2px 6px;border-radius:3px;font-size:13px;font-family:\'SF Mono\',ui-monospace,Menlo,monospace;color:#10b981;">$1</code>')
-    // Links
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" class="email-link" style="color:#10b981;text-decoration:underline;">$1</a>')
+    // Links — sanitize URL to prevent XSS via javascript:/data:/vbscript: schemes
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label: string, href: string) => {
+      const safeUrl = sanitizeLinkUrl(href)
+      if (!safeUrl) {
+        // Security: strip dangerous link, render as plain text only
+        return label
+      }
+      return `<a href="${safeUrl}" class="email-link" style="color:#10b981;text-decoration:underline;">${label}</a>`
+    })
 }

--- a/packages/social-auth/src/AbstractProvider.ts
+++ b/packages/social-auth/src/AbstractProvider.ts
@@ -51,9 +51,10 @@ export abstract class AbstractProvider implements OAuthProvider {
     if (!this._stateless) {
       const state = crypto.randomUUID()
       url.searchParams.set('state', state)
-      // Store state in session for verification on callback
+      // Security: use provider-specific session key to prevent CSRF cross-contamination
+      // when a user starts OAuth with one provider then switches to another.
       if (request?.session?.()) {
-        request.session().put('_social_auth_state', state)
+        request.session().put(`_social_auth_state_${this.name}`, state)
       }
     }
 
@@ -78,17 +79,19 @@ export abstract class AbstractProvider implements OAuthProvider {
       throw new Error('Authorization code not found in callback')
     }
 
-    // Validate state parameter to prevent CSRF
+    // Validate state parameter to prevent CSRF — provider-specific key
+    // so starting Google login doesn't overwrite GitHub's state (or vice versa).
     if (!this._stateless) {
+      const stateKey = `_social_auth_state_${this.name}`
       const callbackState = getParam('state')
-      const sessionState = request?.session?.()?.get('_social_auth_state') ?? null
+      const sessionState = request?.session?.()?.get(stateKey) ?? null
 
       if (!callbackState || !sessionState || callbackState !== sessionState) {
         throw new Error('Invalid OAuth state — possible CSRF attack. State mismatch.')
       }
 
       // Clear used state
-      request?.session?.()?.forget('_social_auth_state')
+      request?.session?.()?.forget(stateKey)
     }
 
     const tokenData = await this.getAccessToken(code)


### PR DESCRIPTION
## Summary

Closes #123 #124 #126 #128 #129

- **#126**: Email markdown strips javascript:/data:/vbscript: protocols
- **#124**: Content-Disposition sanitizes filename (CRLF, quotes, traversal)
- **#123**: OAuth state isolated per provider
- **#129**: CSP uses per-request nonce instead of unsafe-inline/unsafe-eval
- **#128**: Debug error page redacts sensitive headers, removes IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)