### PR TITLE
chore: bump all packages to 0.6.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -50,7 +50,7 @@
     },
     "packages/ai": {
       "name": "@mantiq/ai",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@mantiq/cli": "workspace:*",
         "@mantiq/core": "workspace:*",
@@ -67,7 +67,7 @@
     },
     "packages/auth": {
       "name": "@mantiq/auth",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@mantiq/core": "workspace:*",
         "@mantiq/database": "workspace:*",
@@ -81,7 +81,7 @@
     },
     "packages/cli": {
       "name": "@mantiq/cli",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "bin": {
         "mantiq": "./src/bin.ts",
       },
@@ -98,7 +98,7 @@
     },
     "packages/core": {
       "name": "@mantiq/core",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "bun-types": "latest",
         "typescript": "^5.7.0",
@@ -115,7 +115,7 @@
     },
     "packages/create-mantiq": {
       "name": "create-mantiq",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "bin": {
         "create-mantiq": "./src/index.ts",
       },
@@ -126,7 +126,7 @@
     },
     "packages/database": {
       "name": "@mantiq/database",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@types/pg": "^8.18.0",
         "bun-types": "latest",
@@ -151,7 +151,7 @@
     },
     "packages/events": {
       "name": "@mantiq/events",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@mantiq/auth": "workspace:*",
         "@mantiq/core": "workspace:*",
@@ -171,7 +171,7 @@
     },
     "packages/filesystem": {
       "name": "@mantiq/filesystem",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@mantiq/core": "workspace:*",
         "bun-types": "latest",
@@ -197,7 +197,7 @@
     },
     "packages/health": {
       "name": "@mantiq/health",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "bun-types": "latest",
         "typescript": "^5.7.0",
@@ -208,7 +208,7 @@
     },
     "packages/heartbeat": {
       "name": "@mantiq/heartbeat",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@mantiq/cli": "workspace:*",
         "@mantiq/core": "workspace:*",
@@ -230,7 +230,7 @@
     },
     "packages/helpers": {
       "name": "@mantiq/helpers",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "bun-types": "latest",
         "typescript": "^5.7.0",
@@ -238,7 +238,7 @@
     },
     "packages/logging": {
       "name": "@mantiq/logging",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@mantiq/core": "workspace:*",
         "bun-types": "latest",
@@ -250,7 +250,7 @@
     },
     "packages/mail": {
       "name": "@mantiq/mail",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@mantiq/core": "workspace:*",
         "bun-types": "latest",
@@ -265,7 +265,7 @@
     },
     "packages/notify": {
       "name": "@mantiq/notify",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@mantiq/cli": "workspace:*",
         "@mantiq/core": "workspace:*",
@@ -289,7 +289,7 @@
     },
     "packages/oauth": {
       "name": "@mantiq/oauth",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@mantiq/auth": "workspace:*",
         "@mantiq/core": "workspace:*",
@@ -305,7 +305,7 @@
     },
     "packages/queue": {
       "name": "@mantiq/queue",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@mantiq/cli": "workspace:*",
         "@mantiq/core": "workspace:*",
@@ -327,7 +327,7 @@
     },
     "packages/realtime": {
       "name": "@mantiq/realtime",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@mantiq/core": "workspace:*",
         "@mantiq/events": "workspace:*",
@@ -341,7 +341,7 @@
     },
     "packages/search": {
       "name": "@mantiq/search",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@mantiq/core": "workspace:*",
         "@mantiq/database": "workspace:*",
@@ -355,7 +355,7 @@
     },
     "packages/social-auth": {
       "name": "@mantiq/social-auth",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@mantiq/core": "workspace:*",
         "bun-types": "latest",
@@ -367,7 +367,7 @@
     },
     "packages/testing": {
       "name": "@mantiq/testing",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "bun-types": "latest",
         "typescript": "^5.7.0",
@@ -395,7 +395,7 @@
     },
     "packages/validation": {
       "name": "@mantiq/validation",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@mantiq/core": "workspace:*",
         "bun-types": "latest",
@@ -407,7 +407,7 @@
     },
     "packages/vite": {
       "name": "@mantiq/vite",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "@mantiq/core": "workspace:*",
         "bun-types": "latest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mantiqjs",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "private": true,
   "workspaces": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/ai",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "AI integration — OpenAI, Anthropic, Gemini, Ollama, Azure OpenAI, Bedrock, embeddings, RAG, agents, tool calling",
   "type": "module",
   "license": "MIT",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/auth",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Session & token auth, guards, providers",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Command runner, code generators, dev server",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Service container, router, middleware, HTTP kernel, config, and exception handler",
   "type": "module",
   "license": "MIT",

--- a/packages/create-mantiq/package.json
+++ b/packages/create-mantiq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mantiq",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Scaffold a new MantiqJS application",
   "type": "module",
   "license": "MIT",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/database",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Query builder, ORM, migrations, seeders, factories — with SQLite, Postgres, MySQL and MongoDB support",
   "type": "module",
   "license": "MIT",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/events",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Event dispatcher, listeners, observers, and broadcasting for MantiqJS",
   "type": "module",
   "license": "MIT",

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/filesystem",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Filesystem abstraction — local, S3, GCS, R2, Azure, FTP, SFTP drivers with uniform API",
   "type": "module",
   "license": "MIT",

--- a/packages/health/package.json
+++ b/packages/health/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/health",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Application health checks — database, cache, queue, filesystem, mail, and custom checks",
   "type": "module",
   "license": "MIT",

--- a/packages/heartbeat/package.json
+++ b/packages/heartbeat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/heartbeat",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Observability, APM & queue monitoring for MantiqJS",
   "type": "module",
   "license": "MIT",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/helpers",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Str, Arr, Num, Collection utilities",
   "type": "module",
   "license": "MIT",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/logging",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Channel-based logging",
   "type": "module",
   "license": "MIT",

--- a/packages/mail/package.json
+++ b/packages/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/mail",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Transactional email — SMTP, Resend, SendGrid, Mailgun, Postmark, SES, markdown templates",
   "type": "module",
   "license": "MIT",

--- a/packages/notify/package.json
+++ b/packages/notify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/notify",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Multi-channel notifications — mail, database, broadcast, SMS, Slack, webhook",
   "type": "module",
   "license": "MIT",

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/oauth",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "OAuth 2.0 server — authorization code (PKCE), client credentials, JWT access tokens, scopes",
   "type": "module",
   "license": "MIT",

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/queue",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Job dispatching, workers, retry logic",
   "type": "module",
   "license": "MIT",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/realtime",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "WebSocket, SSE, channels, broadcasting",
   "type": "module",
   "license": "MIT",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/search",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Full-text search abstraction — Algolia, Meilisearch, Typesense, Elasticsearch, database, and collection drivers",
   "type": "module",
   "license": "MIT",

--- a/packages/social-auth/package.json
+++ b/packages/social-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/social-auth",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Social authentication — login with Google, GitHub, Facebook, Apple, and more via extensible providers",
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/testing",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Testing utilities for MantiqJS — HTTP client, database assertions, auth helpers",
   "type": "module",
   "license": "MIT",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/validation",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Rule engine, form requests",
   "type": "module",
   "license": "MIT",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mantiq/vite",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Vite dev server & manifest integration",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Patch release — publishes create-mantiq which failed on 0.6.0.