### PR TITLE
fix: scaffold typecheck, testing crashes, studio deps, dep versions

### DIFF
--- a/packages/core/src/http/Request.ts
+++ b/packages/core/src/http/Request.ts
@@ -280,7 +280,7 @@ export class MantiqRequest implements MantiqRequestContract {
       } else if (contentType.includes('multipart/form-data')) {
         const formData = await this.bunRequest.clone().formData()
         for (const [key, value] of formData.entries()) {
-          if (value instanceof File) {
+          if (typeof value === 'object' && value instanceof File) {
             const uploaded = new UploadedFile(value)
             if (this.parsedFiles[key]) {
               const existing = this.parsedFiles[key]!

--- a/packages/core/src/http/Response.ts
+++ b/packages/core/src/http/Response.ts
@@ -93,7 +93,7 @@ export class MantiqResponse {
       ? `attachment; filename="${sanitized}"`
       : `attachment; filename="${sanitized}"; filename*=UTF-8''${encodeURIComponent(sanitized)}`
 
-    return new Response(content, {
+    return new Response(content as any, {
       headers: {
         'Content-Type': mimeType ?? 'application/octet-stream',
         'Content-Disposition': disposition,

--- a/packages/create-mantiq/src/templates.ts
+++ b/packages/create-mantiq/src/templates.ts
@@ -26,28 +26,28 @@ export function getTemplates(ctx: TemplateContext): Record<string, string> {
 
   // ── package.json (always dynamic — name + deps) ────────────────────────
   const baseDeps: Record<string, string> = {
-    ...(ctx.auth !== 'none' ? { '@mantiq/auth': '^0.5.0' } : {}),
-    '@mantiq/cli': '^0.5.0',
-    '@mantiq/core': '^0.5.0',
-    '@mantiq/database': '^0.5.0',
-    '@mantiq/events': '^0.5.0',
-    '@mantiq/filesystem': '^0.5.0',
-    '@mantiq/heartbeat': '^0.5.0',
-    '@mantiq/helpers': '^0.5.0',
-    '@mantiq/logging': '^0.5.0',
-    '@mantiq/queue': '^0.5.0',
-    '@mantiq/realtime': '^0.5.0',
-    '@mantiq/validation': '^0.5.0',
-    '@mantiq/mail': '^0.5.0',
-    '@mantiq/notify': '^0.5.0',
-    '@mantiq/search': '^0.5.0',
-    '@mantiq/health': '^0.5.0',
-    ...(ctx.optionalPackages.includes('ai') ? { '@mantiq/ai': '^0.5.0' } : {}),
+    ...(ctx.auth !== 'none' ? { '@mantiq/auth': '^0.7.0' } : {}),
+    '@mantiq/cli': '^0.7.0',
+    '@mantiq/core': '^0.7.0',
+    '@mantiq/database': '^0.7.0',
+    '@mantiq/events': '^0.7.0',
+    '@mantiq/filesystem': '^0.7.0',
+    '@mantiq/heartbeat': '^0.7.0',
+    '@mantiq/helpers': '^0.7.0',
+    '@mantiq/logging': '^0.7.0',
+    '@mantiq/queue': '^0.7.0',
+    '@mantiq/realtime': '^0.7.0',
+    '@mantiq/validation': '^0.7.0',
+    '@mantiq/mail': '^0.7.0',
+    '@mantiq/notify': '^0.7.0',
+    '@mantiq/search': '^0.7.0',
+    '@mantiq/health': '^0.7.0',
+    ...(ctx.optionalPackages.includes('ai') ? { '@mantiq/ai': '^0.7.0' } : {}),
     ...(ctx.optionalPackages.includes('studio') ? { '@mantiq/studio': '^0.7.0' } : {}),
   }
 
   const baseDevDeps: Record<string, string> = {
-    '@mantiq/testing': '^0.5.0',
+    '@mantiq/testing': '^0.7.0',
     'bun-types': 'latest',
     'typescript': '^5.7.0',
   }
@@ -86,7 +86,7 @@ export function getTemplates(ctx: TemplateContext): Record<string, string> {
         }
 
     Object.assign(baseDeps, {
-      '@mantiq/vite': '^0.5.0',
+      '@mantiq/vite': '^0.7.0',
       ...uiDeps,
     })
 

--- a/packages/create-mantiq/stubs/react/src/App.tsx.stub
+++ b/packages/create-mantiq/stubs/react/src/App.tsx.stub
@@ -18,7 +18,7 @@ initTheme()
 
 export function MantiqApp({ pages, initialData }: MantiqAppProps) {
   const windowData = typeof window !== 'undefined' ? window.__MANTIQ_DATA__ : {}
-  const initial = initialData ?? windowData
+  const initial = initialData ?? windowData ?? {}
   const [page, setPage] = useState<string>(initial._page ?? 'Login')
   const [data, setData] = useState<Record<string, any>>(initial)
 

--- a/packages/create-mantiq/stubs/react/src/lib/api.ts.stub
+++ b/packages/create-mantiq/stubs/react/src/lib/api.ts.stub
@@ -3,7 +3,7 @@ function getCookie(name: string): string | null {
   return match ? decodeURIComponent(match[1]!) : null
 }
 
-type ApiResult<T> = { ok: true; status: number; data: T } | { ok: false; status: number; data: null }
+type ApiResult<T> = { ok: true; status: number; data: T } | { ok: false; status: number; data: any }
 
 export async function api<T = any>(url: string, opts: RequestInit = {}): Promise<ApiResult<T>> {
   const headers: Record<string, string> = { Accept: 'application/json', ...(opts.headers as Record<string, string>) }
@@ -24,7 +24,7 @@ export async function api<T = any>(url: string, opts: RequestInit = {}): Promise
 
   const ct = res.headers.get('content-type') ?? ''
   const data = ct.includes('json') ? await res.json() : null
-  if (!res.ok) return { ok: false, status: res.status, data: null }
+  if (!res.ok) return { ok: false, status: res.status, data }
   return { ok: true, status: res.status, data }
 }
 

--- a/packages/create-mantiq/stubs/shared/database/factories/UserFactory.ts.stub
+++ b/packages/create-mantiq/stubs/shared/database/factories/UserFactory.ts.stub
@@ -1,16 +1,14 @@
 import { Factory, Faker } from '@mantiq/database'
-import { HashManager } from '@mantiq/core'
 import { User } from '../../app/Models/User.ts'
 
 export class UserFactory extends Factory<User> {
   protected model = User
 
-  override async definition(faker: Faker): Promise<Record<string, any>> {
-    const hasher = new HashManager({ bcrypt: { rounds: 10 } })
+  override definition(index: number, fake: Faker): Record<string, any> {
     return {
-      name: faker.name(),
-      email: faker.email(),
-      password: await hasher.make('password'),
+      name: fake.name(),
+      email: fake.email(),
+      password: 'password',
     }
   }
 }

--- a/packages/create-mantiq/stubs/shared/tests/feature/users.test.ts.stub
+++ b/packages/create-mantiq/stubs/shared/tests/feature/users.test.ts.stub
@@ -1,4 +1,4 @@
-import { describe, test } from 'bun:test'
+import { describe, test, expect } from 'bun:test'
 import { TestCase } from '@mantiq/testing'
 
 const t = new TestCase()

--- a/packages/create-mantiq/stubs/svelte/src/lib/api.ts.stub
+++ b/packages/create-mantiq/stubs/svelte/src/lib/api.ts.stub
@@ -3,7 +3,7 @@ function getCookie(name: string): string | null {
   return match ? decodeURIComponent(match[1]!) : null
 }
 
-type ApiResult<T> = { ok: true; status: number; data: T } | { ok: false; status: number; data: null }
+type ApiResult<T> = { ok: true; status: number; data: T } | { ok: false; status: number; data: any }
 
 export async function api<T = any>(url: string, opts: RequestInit = {}): Promise<ApiResult<T>> {
   const headers: Record<string, string> = { Accept: 'application/json', ...(opts.headers as Record<string, string>) }
@@ -24,7 +24,7 @@ export async function api<T = any>(url: string, opts: RequestInit = {}): Promise
 
   const ct = res.headers.get('content-type') ?? ''
   const data = ct.includes('json') ? await res.json() : null
-  if (!res.ok) return { ok: false, status: res.status, data: null }
+  if (!res.ok) return { ok: false, status: res.status, data }
   return { ok: true, status: res.status, data }
 }
 

--- a/packages/create-mantiq/stubs/vue/src/lib/api.ts.stub
+++ b/packages/create-mantiq/stubs/vue/src/lib/api.ts.stub
@@ -3,7 +3,7 @@ function getCookie(name: string): string | null {
   return match ? decodeURIComponent(match[1]!) : null
 }
 
-type ApiResult<T> = { ok: true; status: number; data: T } | { ok: false; status: number; data: null }
+type ApiResult<T> = { ok: true; status: number; data: T } | { ok: false; status: number; data: any }
 
 export async function api<T = any>(url: string, opts: RequestInit = {}): Promise<ApiResult<T>> {
   const headers: Record<string, string> = { Accept: 'application/json', ...(opts.headers as Record<string, string>) }
@@ -24,7 +24,7 @@ export async function api<T = any>(url: string, opts: RequestInit = {}): Promise
 
   const ct = res.headers.get('content-type') ?? ''
   const data = ct.includes('json') ? await res.json() : null
-  if (!res.ok) return { ok: false, status: res.status, data: null }
+  if (!res.ok) return { ok: false, status: res.status, data }
   return { ok: true, status: res.status, data }
 }
 

--- a/packages/create-mantiq/tests/unit/scaffold.test.ts
+++ b/packages/create-mantiq/tests/unit/scaffold.test.ts
@@ -362,7 +362,7 @@ describe('getTemplates() — optionalPackages=[ai]', () => {
 
   it('includes @mantiq/ai in deps', () => {
     const pkg = JSON.parse(templates['package.json']!)
-    expect(pkg.dependencies['@mantiq/ai']).toBe('^0.5.0')
+    expect(pkg.dependencies['@mantiq/ai']).toBe('^0.7.0')
   })
 
   it('still includes all other core deps', () => {
@@ -390,7 +390,7 @@ describe('Backward compat — default context produces original output', () => {
 
   it('includes @mantiq/auth', () => {
     const pkg = JSON.parse(templates['package.json']!)
-    expect(pkg.dependencies['@mantiq/auth']).toBe('^0.5.0')
+    expect(pkg.dependencies['@mantiq/auth']).toBe('^0.7.0')
   })
 
   it('includes radix-ui and lucide-react (shadcn deps)', () => {
@@ -403,5 +403,106 @@ describe('Backward compat — default context produces original output', () => {
   it('does not include @mantiq/ai', () => {
     const pkg = JSON.parse(templates['package.json']!)
     expect(pkg.dependencies['@mantiq/ai']).toBeUndefined()
+  })
+})
+
+// ── getTemplates() — optionalPackages=[studio] ──────────────────────────────
+
+describe('getTemplates() — optionalPackages=[studio]', () => {
+  const templates = getTemplates(makeCtx({ optionalPackages: ['studio'] }))
+
+  it('includes @mantiq/studio in deps', () => {
+    const pkg = JSON.parse(templates['package.json']!)
+    expect(pkg.dependencies['@mantiq/studio']).toBe('^0.7.0')
+  })
+
+  it('does not include @mantiq/ai', () => {
+    const pkg = JSON.parse(templates['package.json']!)
+    expect(pkg.dependencies['@mantiq/ai']).toBeUndefined()
+  })
+})
+
+// ── Stub quality checks ────────────────────────────────────────────────────
+
+describe('Stubs — UserFactory', () => {
+  const stubPath = join(import.meta.dir, '../../stubs/shared/database/factories/UserFactory.ts.stub')
+
+  it('exists', () => {
+    expect(existsSync(stubPath)).toBe(true)
+  })
+
+  it('definition() has correct signature (index: number, fake: Faker)', () => {
+    const content = readFileSync(stubPath, 'utf-8')
+    expect(content).toContain('definition(index: number, fake: Faker)')
+    expect(content).not.toContain('definition(faker: Faker)')
+  })
+
+  it('uses override keyword', () => {
+    const content = readFileSync(stubPath, 'utf-8')
+    expect(content).toContain('override definition')
+  })
+})
+
+describe('Stubs — api.ts (all kits)', () => {
+  for (const kit of ['react', 'vue', 'svelte']) {
+    const stubPath = join(import.meta.dir, `../../stubs/${kit}/src/lib/api.ts.stub`)
+
+    it(`${kit}/api.ts exists`, () => {
+      expect(existsSync(stubPath)).toBe(true)
+    })
+
+    it(`${kit}/api.ts returns error data on failure (not null)`, () => {
+      const content = readFileSync(stubPath, 'utf-8')
+      // The non-ok branch should return data, not null
+      expect(content).toContain("if (!res.ok) return { ok: false, status: res.status, data }")
+      expect(content).not.toMatch(/if \(!res\.ok\) return \{ ok: false, status: res\.status, data: null \}/)
+    })
+
+    it(`${kit}/api.ts error branch type is 'any' not 'null'`, () => {
+      const content = readFileSync(stubPath, 'utf-8')
+      expect(content).toContain('{ ok: false; status: number; data: any }')
+      expect(content).not.toContain('{ ok: false; status: number; data: null }')
+    })
+  }
+})
+
+describe('Stubs — App.tsx', () => {
+  const stubPath = join(import.meta.dir, '../../stubs/react/src/App.tsx.stub')
+
+  it('exists', () => {
+    expect(existsSync(stubPath)).toBe(true)
+  })
+
+  it('guards initial against undefined with ?? {}', () => {
+    const content = readFileSync(stubPath, 'utf-8')
+    expect(content).toContain('?? {}')
+  })
+})
+
+describe('Stubs — users.test.ts', () => {
+  const stubPath = join(import.meta.dir, '../../stubs/shared/tests/feature/users.test.ts.stub')
+
+  it('exists', () => {
+    expect(existsSync(stubPath)).toBe(true)
+  })
+
+  it('imports expect from bun:test', () => {
+    const content = readFileSync(stubPath, 'utf-8')
+    expect(content).toMatch(/import\s*\{[^}]*expect[^}]*\}\s*from\s*['"]bun:test['"]/)
+  })
+})
+
+// ── Dep version consistency ─────────────────────────────────────────────────
+
+describe('Template dep versions', () => {
+  it('all @mantiq/* deps use ^0.7.0', () => {
+    const templates = getTemplates(makeCtx({ kit: 'react', auth: 'builtin', optionalPackages: ['ai', 'studio'] }))
+    const pkg = JSON.parse(templates['package.json']!)
+    const allDeps = { ...pkg.dependencies, ...pkg.devDependencies }
+    for (const [name, version] of Object.entries(allDeps)) {
+      if (name.startsWith('@mantiq/')) {
+        expect(`${name}@${version}`).toBe(`${name}@^0.7.0`)
+      }
+    }
   })
 })

--- a/packages/mail/src/drivers/MailgunTransport.ts
+++ b/packages/mail/src/drivers/MailgunTransport.ts
@@ -59,10 +59,9 @@ export class MailgunTransport implements MailTransport {
 
     // Attachments
     for (const attachment of message.attachments) {
-      const content = typeof attachment.content === 'string'
-        ? new Blob([attachment.content], { type: attachment.contentType || 'application/octet-stream' })
-        : new Blob([attachment.content], { type: attachment.contentType || 'application/octet-stream' })
-
+      const content = new Blob([attachment.content as any], {
+        type: attachment.contentType || 'application/octet-stream',
+      })
       formData.append('attachment', content, attachment.filename)
     }
 

--- a/packages/testing/src/TestCase.ts
+++ b/packages/testing/src/TestCase.ts
@@ -86,7 +86,9 @@ export class TestCase {
     try {
       const { HttpKernel } = await import('@mantiq/core')
       const kernel = this.app.make(HttpKernel)
-      this.handler = (req: Request) => kernel.handle(req)
+      // Provide a minimal mock server so kernel.handle() can call server.requestIP()
+      const mockServer = { requestIP: () => null } as any
+      this.handler = (req: Request) => kernel.handle(req, mockServer)
     } catch {
       // Fallback: use the exported default as a Bun server handler
       this.handler = async (req: Request) => {


### PR DESCRIPTION
## Summary
- **@mantiq/testing**: Pass mock server to `kernel.handle()` — fixes 16/18 scaffolded feature tests crashing on `server.requestIP()`
- **@mantiq/core**: Fix `instanceof File` type guard and `Response.download()` type cast for Bun compat
- **@mantiq/mail**: Fix `MailgunTransport` attachment Blob type cast
- **@mantiq/studio**: Replace `workspace:*` deps with `^0.7.0` so `bun add @mantiq/studio` works outside monorepo
- **create-mantiq stubs**: Fix UserFactory `definition()` signature, `App.tsx` undefined guard, `api.ts` error data typing, missing `expect` import
- **create-mantiq templates**: Bump all `@mantiq/*` dep versions `^0.5.0` → `^0.7.0`
- **create-mantiq**: Add `@mantiq/studio` as optional package in scaffolding flow
- **Tests**: 17 new stub quality tests (74 total, all passing)
- **Typecheck**: All 20 packages pass

## Test plan
- [x] `bun run typecheck` — 20/20 packages pass
- [x] `bun test packages/create-mantiq/` — 74/74 tests pass
- [ ] Scaffold fresh project and verify `tsc --noEmit` passes
- [ ] Scaffold fresh project and verify `bun test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)