### PR TITLE
feat(create-mantiq): add @mantiq/agent-rules to scaffolded devDeps

### DIFF
--- a/packages/create-mantiq/src/templates.ts
+++ b/packages/create-mantiq/src/templates.ts
@@ -47,6 +47,7 @@ export function getTemplates(ctx: TemplateContext): Record<string, string> {
   }
 
   const baseDevDeps: Record<string, string> = {
+    '@mantiq/agent-rules': '^0.7.0',
     '@mantiq/testing': '^0.7.0',
     'bun-types': 'latest',
     'typescript': '^5.7.0',


### PR DESCRIPTION
## Summary
- Re-add `@mantiq/agent-rules` to scaffolded project devDependencies now that it's published on npm (0.7.2)
- New projects get `bun mantiq agent:generate` working out of the box

## Test plan
- [x] `@mantiq/agent-rules@0.7.2` confirmed on npm registry
- [x] Previous CI run passed with all scaffold sanity checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)